### PR TITLE
Central Money Exchange - August 26, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/08/26/central-money-exchange-20250826T021844691/README.md
+++ b/exchange-rates/2025/08/26/central-money-exchange-20250826T021844691/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-08-26 02:18:44
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-08-26 |
+| Method | POST |
+| Timestamp | 2025-08-26T02:18:44.691268-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 26 Aug 2025 05:30:44 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| X-Aspnetmvc-Version | 5.2 |
+| X-Aspnet-Version | 4.0.30319 |
+| X-Powered-By | ASP.NET |
+| Cf-Cache-Status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=phihk7PVKKussZfTCT8HLGDMn4wG00GPaLNjqyo8l9ybbAv1hnFQZMgK309DXXsAL5r1J0L2Shm9iFr%2BKyfv7MgT4BEMnI2i%2Bbk%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 9750f057e86d8736-PDX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.48.1), 15 hops max
+  1   140.91.194.97  0.260ms  0.147ms  0.129ms 
+  2   140.204.28.36  10.042ms  10.000ms  10.008ms 
+  3   *  140.204.28.37  11.315ms  * 
+  4   141.101.72.21  9.596ms  8.780ms  9.186ms 
+  5   104.21.48.1  10.641ms  10.594ms  10.597ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.00 | 37.50 |
+| EUR | 42.05 | 43.15 |

--- a/exchange-rates/2025/08/26/central-money-exchange-20250826T021844691/request.json
+++ b/exchange-rates/2025/08/26/central-money-exchange-20250826T021844691/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-08-26T02:18:44.691268-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-08-26",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.48.1), 15 hops max\n  1   140.91.194.97  0.260ms  0.147ms  0.129ms \n  2   140.204.28.36  10.042ms  10.000ms  10.008ms \n  3   *  140.204.28.37  11.315ms  * \n  4   141.101.72.21  9.596ms  8.780ms  9.186ms \n  5   104.21.48.1  10.641ms  10.594ms  10.597ms \n"
+}

--- a/exchange-rates/2025/08/26/central-money-exchange-20250826T021844691/response.json
+++ b/exchange-rates/2025/08/26/central-money-exchange-20250826T021844691/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 26 Aug 2025 05:30:44 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "X-Aspnetmvc-Version": "5.2",
+    "X-Aspnet-Version": "4.0.30319",
+    "X-Powered-By": "ASP.NET",
+    "Cf-Cache-Status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=phihk7PVKKussZfTCT8HLGDMn4wG00GPaLNjqyo8l9ybbAv1hnFQZMgK309DXXsAL5r1J0L2Shm9iFr%2BKyfv7MgT4BEMnI2i%2Bbk%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "9750f057e86d8736-PDX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.0000,\"BuyEuroExchangeRate\":42.0500,\"SaleUsdExchangeRate\":37.5000,\"SaleEuroExchangeRate\":43.1500,\"ExchangeUsdRate\":1.1000,\"ExchangeEuroRate\":1.1300,\"ExchangeUsdRateNew\":1.1300,\"ExchangeEuroRateNew\":1.1000,\"Day\":null,\"BusinessDate\":\"26-Aug-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"02:30 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/08/26/central-money-exchange-20250826T021844691/results.json
+++ b/exchange-rates/2025/08/26/central-money-exchange-20250826T021844691/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.00",
+    "sell": "37.50",
+    "updated_on": "2025-08-26",
+    "updated_on_time": "02:30 AM"
+  },
+  "EUR": {
+    "buy": "42.05",
+    "sell": "43.15",
+    "updated_on": "2025-08-26",
+    "updated_on_time": "02:30 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/08/26/central-money-exchange-20250826T021844691) in the repository.