### PR TITLE
Central Money Exchange - September 2, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T102040103/README.md
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T102040103/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-02 10:20:40
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-02 |
+| Method | POST |
+| Timestamp | 2025-09-02T10:20:40.103128-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 02 Sep 2025 13:30:37 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=Kt2A%2FtVt6v3wNXX7ezjLxJ9VU8wiVbjT1Hvyh0FRWu5TQk5G0D9E%2FqMtU77dGHgd3BbwmFHBqvjS3L3LemCUMKr7KiMBDdW5TZM%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 978d5ce5082afea6-AMS |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.112.1), 15 hops max
+  1   140.91.194.17  0.287ms  0.119ms  0.120ms 
+  2   140.204.28.36  8.443ms  8.425ms  8.770ms 
+  3   140.204.28.37  10.790ms  11.501ms  * 
+  4   141.101.72.27  80.810ms  13.035ms  11.965ms 
+  5   104.21.112.1  11.993ms  11.952ms  11.957ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.50 | 38.20 |
+| EUR | 42.75 | 43.70 |

--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T102040103/request.json
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T102040103/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-02T10:20:40.103128-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-02",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.112.1), 15 hops max\n  1   140.91.194.17  0.287ms  0.119ms  0.120ms \n  2   140.204.28.36  8.443ms  8.425ms  8.770ms \n  3   140.204.28.37  10.790ms  11.501ms  * \n  4   141.101.72.27  80.810ms  13.035ms  11.965ms \n  5   104.21.112.1  11.993ms  11.952ms  11.957ms \n"
+}

--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T102040103/response.json
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T102040103/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 02 Sep 2025 13:30:37 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=Kt2A%2FtVt6v3wNXX7ezjLxJ9VU8wiVbjT1Hvyh0FRWu5TQk5G0D9E%2FqMtU77dGHgd3BbwmFHBqvjS3L3LemCUMKr7KiMBDdW5TZM%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "978d5ce5082afea6-AMS",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5000,\"BuyEuroExchangeRate\":42.7500,\"SaleUsdExchangeRate\":38.2000,\"SaleEuroExchangeRate\":43.7000,\"ExchangeUsdRate\":1.1080,\"ExchangeEuroRate\":1.1350,\"ExchangeUsdRateNew\":1.1350,\"ExchangeEuroRateNew\":1.1080,\"Day\":null,\"BusinessDate\":\"02-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"10:30 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T102040103/results.json
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T102040103/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.50",
+    "sell": "38.20",
+    "updated_on": "2025-09-02",
+    "updated_on_time": "10:30 AM"
+  },
+  "EUR": {
+    "buy": "42.75",
+    "sell": "43.70",
+    "updated_on": "2025-09-02",
+    "updated_on_time": "10:30 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/02/central-money-exchange-20250902T102040103) in the repository.