### PR TITLE
Central Money Exchange - September 2, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T130314158/README.md
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T130314158/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-02 13:03:14
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-02 |
+| Method | POST |
+| Timestamp | 2025-09-02T13:03:14.158517-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 02 Sep 2025 16:13:40 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=MDftbi3dna7WZYTlidnNBuQHkLMfB88Kc6mbDgDDDaEXnDcs3W691EJ8Mh04KRkU%2FRIQOJU5tIWUrxJODU0fhYO%2F0eno7SXCkm8%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 978e4bc30b841c9a-AMS |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.32.1), 15 hops max
+  1   140.204.226.195  0.270ms  0.221ms  0.144ms 
+  2   140.204.28.36  10.062ms  10.048ms  9.929ms 
+  3   *  140.204.28.37  15.546ms  20.783ms 
+  4   141.101.72.27  13.867ms  18.126ms  10.791ms 
+  5   104.21.32.1  10.581ms  10.696ms  10.566ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.50 | 38.20 |
+| EUR | 42.75 | 43.70 |

--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T130314158/request.json
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T130314158/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-02T13:03:14.158517-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-02",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.32.1), 15 hops max\n  1   140.204.226.195  0.270ms  0.221ms  0.144ms \n  2   140.204.28.36  10.062ms  10.048ms  9.929ms \n  3   *  140.204.28.37  15.546ms  20.783ms \n  4   141.101.72.27  13.867ms  18.126ms  10.791ms \n  5   104.21.32.1  10.581ms  10.696ms  10.566ms \n"
+}

--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T130314158/response.json
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T130314158/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 02 Sep 2025 16:13:40 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=MDftbi3dna7WZYTlidnNBuQHkLMfB88Kc6mbDgDDDaEXnDcs3W691EJ8Mh04KRkU%2FRIQOJU5tIWUrxJODU0fhYO%2F0eno7SXCkm8%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "978e4bc30b841c9a-AMS",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5000,\"BuyEuroExchangeRate\":42.7500,\"SaleUsdExchangeRate\":38.2000,\"SaleEuroExchangeRate\":43.7000,\"ExchangeUsdRate\":1.1080,\"ExchangeEuroRate\":1.1350,\"ExchangeUsdRateNew\":1.1350,\"ExchangeEuroRateNew\":1.1080,\"Day\":null,\"BusinessDate\":\"02-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"01:13 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T130314158/results.json
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T130314158/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.50",
+    "sell": "38.20",
+    "updated_on": "2025-09-02",
+    "updated_on_time": "01:13 PM"
+  },
+  "EUR": {
+    "buy": "42.75",
+    "sell": "43.70",
+    "updated_on": "2025-09-02",
+    "updated_on_time": "01:13 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/02/central-money-exchange-20250902T130314158) in the repository.