### PR TITLE
Central Money Exchange - September 2, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T235517010/README.md
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T235517010/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-02 23:55:17
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-02 |
+| Method | POST |
+| Timestamp | 2025-09-02T23:55:17.010849-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 03 Sep 2025 03:06:41 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=%2Fv31QWzvnZmYjohHqLcfQSQdMyfq6e8bUu2q6SPqzdJH1hux6FDczg%2FOiItBsyEFxkEAMidecBDrxtxRWJyih0bWQv2yPh89IKU%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 979208557d9245f5-ORD |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.32.1), 15 hops max
+  1   140.91.194.17  0.256ms  0.157ms  0.133ms 
+  2   140.204.28.36  10.038ms  10.161ms  9.983ms 
+  3   140.204.28.37  12.570ms  *  * 
+  4   141.101.72.27  12.652ms  12.242ms  12.072ms 
+  5   104.21.32.1  12.182ms  11.959ms  11.979ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.50 | 38.20 |
+| EUR | 42.75 | 43.70 |

--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T235517010/request.json
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T235517010/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-02T23:55:17.010849-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-02",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.32.1), 15 hops max\n  1   140.91.194.17  0.256ms  0.157ms  0.133ms \n  2   140.204.28.36  10.038ms  10.161ms  9.983ms \n  3   140.204.28.37  12.570ms  *  * \n  4   141.101.72.27  12.652ms  12.242ms  12.072ms \n  5   104.21.32.1  12.182ms  11.959ms  11.979ms \n"
+}

--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T235517010/response.json
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T235517010/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 03 Sep 2025 03:06:41 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=%2Fv31QWzvnZmYjohHqLcfQSQdMyfq6e8bUu2q6SPqzdJH1hux6FDczg%2FOiItBsyEFxkEAMidecBDrxtxRWJyih0bWQv2yPh89IKU%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "979208557d9245f5-ORD",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5000,\"BuyEuroExchangeRate\":42.7500,\"SaleUsdExchangeRate\":38.2000,\"SaleEuroExchangeRate\":43.7000,\"ExchangeUsdRate\":1.1080,\"ExchangeEuroRate\":1.1350,\"ExchangeUsdRateNew\":1.1350,\"ExchangeEuroRateNew\":1.1080,\"Day\":null,\"BusinessDate\":\"03-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"12:06 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/02/central-money-exchange-20250902T235517010/results.json
+++ b/exchange-rates/2025/09/02/central-money-exchange-20250902T235517010/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.50",
+    "sell": "38.20",
+    "updated_on": "2025-09-02",
+    "updated_on_time": "12:06 AM"
+  },
+  "EUR": {
+    "buy": "42.75",
+    "sell": "43.70",
+    "updated_on": "2025-09-02",
+    "updated_on_time": "12:06 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/02/central-money-exchange-20250902T235517010) in the repository.