### PR TITLE
Central Money Exchange - September 4, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/04/central-money-exchange-20250904T110811176/README.md
+++ b/exchange-rates/2025/09/04/central-money-exchange-20250904T110811176/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-04 11:08:11
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-04 |
+| Method | POST |
+| Timestamp | 2025-09-04T11:08:11.176059-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 04 Sep 2025 14:18:38 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=ayfnuOk2Gj29VHXA%2Ff3gbDef8O7w%2FvKcm5tVF4LJaO1xdnWFn3ht3CDNwa4jmO4SxhpjF00jwrX0DK9KdyHW%2FHp1XdutAF2zm8M%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 979e1e001e5a2eed-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.64.1), 15 hops max
+  1   140.204.227.33  0.257ms  0.129ms  0.114ms 
+  2   140.204.28.36  9.961ms  10.108ms  9.860ms 
+  3   140.204.28.37  10.624ms  10.599ms  10.642ms 
+  4   141.101.72.31  24.488ms  22.076ms  15.886ms 
+  5   104.21.64.1  10.567ms  10.639ms  11.484ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.50 |
+| EUR | 43.60 | 44.40 |

--- a/exchange-rates/2025/09/04/central-money-exchange-20250904T110811176/request.json
+++ b/exchange-rates/2025/09/04/central-money-exchange-20250904T110811176/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-04T11:08:11.176059-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-04",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.64.1), 15 hops max\n  1   140.204.227.33  0.257ms  0.129ms  0.114ms \n  2   140.204.28.36  9.961ms  10.108ms  9.860ms \n  3   140.204.28.37  10.624ms  10.599ms  10.642ms \n  4   141.101.72.31  24.488ms  22.076ms  15.886ms \n  5   104.21.64.1  10.567ms  10.639ms  11.484ms \n"
+}

--- a/exchange-rates/2025/09/04/central-money-exchange-20250904T110811176/response.json
+++ b/exchange-rates/2025/09/04/central-money-exchange-20250904T110811176/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 04 Sep 2025 14:18:38 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=ayfnuOk2Gj29VHXA%2Ff3gbDef8O7w%2FvKcm5tVF4LJaO1xdnWFn3ht3CDNwa4jmO4SxhpjF00jwrX0DK9KdyHW%2FHp1XdutAF2zm8M%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "979e1e001e5a2eed-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.6000,\"SaleUsdExchangeRate\":38.5000,\"SaleEuroExchangeRate\":44.4000,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"04-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"11:18 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/04/central-money-exchange-20250904T110811176/results.json
+++ b/exchange-rates/2025/09/04/central-money-exchange-20250904T110811176/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.50",
+    "updated_on": "2025-09-04",
+    "updated_on_time": "11:18 AM"
+  },
+  "EUR": {
+    "buy": "43.60",
+    "sell": "44.40",
+    "updated_on": "2025-09-04",
+    "updated_on_time": "11:18 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/04/central-money-exchange-20250904T110811176) in the repository.