### PR TITLE
Central Money Exchange - September 4, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/04/central-money-exchange-20250904T122852148/README.md
+++ b/exchange-rates/2025/09/04/central-money-exchange-20250904T122852148/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-04 12:28:52
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-04 |
+| Method | POST |
+| Timestamp | 2025-09-04T12:28:52.148773-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 04 Sep 2025 15:39:49 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=CCnCVNQL3YDFBgqsgSNtW0hqqs9gqD1M8n%2FIByhLMaUHf%2FRPtmNNXfnjBE9rTHh%2F4WSAQAE4AKLoSveVuRGwhftbnPN4vb79GG8%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 979e94ed4f227c83-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.48.1), 15 hops max
+  1   140.204.226.201  0.152ms  0.100ms  0.176ms 
+  2   140.204.28.36  10.050ms  10.003ms  10.053ms 
+  3   *  140.204.28.37  17.054ms  * 
+  4   141.101.72.31  10.395ms  10.962ms  11.162ms 
+  5   104.21.48.1  10.509ms  10.168ms  10.343ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.50 |
+| EUR | 43.60 | 44.40 |

--- a/exchange-rates/2025/09/04/central-money-exchange-20250904T122852148/request.json
+++ b/exchange-rates/2025/09/04/central-money-exchange-20250904T122852148/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-04T12:28:52.148773-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-04",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.48.1), 15 hops max\n  1   140.204.226.201  0.152ms  0.100ms  0.176ms \n  2   140.204.28.36  10.050ms  10.003ms  10.053ms \n  3   *  140.204.28.37  17.054ms  * \n  4   141.101.72.31  10.395ms  10.962ms  11.162ms \n  5   104.21.48.1  10.509ms  10.168ms  10.343ms \n"
+}

--- a/exchange-rates/2025/09/04/central-money-exchange-20250904T122852148/response.json
+++ b/exchange-rates/2025/09/04/central-money-exchange-20250904T122852148/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 04 Sep 2025 15:39:49 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=CCnCVNQL3YDFBgqsgSNtW0hqqs9gqD1M8n%2FIByhLMaUHf%2FRPtmNNXfnjBE9rTHh%2F4WSAQAE4AKLoSveVuRGwhftbnPN4vb79GG8%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "979e94ed4f227c83-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.6000,\"SaleUsdExchangeRate\":38.5000,\"SaleEuroExchangeRate\":44.4000,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"04-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"12:39 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/04/central-money-exchange-20250904T122852148/results.json
+++ b/exchange-rates/2025/09/04/central-money-exchange-20250904T122852148/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.50",
+    "updated_on": "2025-09-04",
+    "updated_on_time": "12:39 PM"
+  },
+  "EUR": {
+    "buy": "43.60",
+    "sell": "44.40",
+    "updated_on": "2025-09-04",
+    "updated_on_time": "12:39 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/04/central-money-exchange-20250904T122852148) in the repository.