### PR TITLE
Central Money Exchange - September 5, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/05/central-money-exchange-20250905T032257835/README.md
+++ b/exchange-rates/2025/09/05/central-money-exchange-20250905T032257835/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-05 03:22:57
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-05 |
+| Method | POST |
+| Timestamp | 2025-09-05T03:22:57.835509-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Fri, 05 Sep 2025 06:33:26 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=CPArmrDK95WD%2BYIMm0w%2FHAIo3vPA8TkPYmxw5A0n1N%2Bzje8ixurJNtQffMcmMeHvFsEn7dTw2Fa0tPjSh9mWAS5B0xvD2v3ElKg%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97a3b1efa8f1b8bd-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.32.1), 15 hops max
+  1   140.204.227.49  0.270ms  0.144ms  0.131ms 
+  2   140.204.28.36  11.617ms  11.571ms  11.601ms 
+  3   *  *  * 
+  4   141.101.72.31  9.195ms  8.816ms  9.715ms 
+  5   104.21.32.1  10.583ms  10.532ms  10.550ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.50 |
+| EUR | 43.70 | 44.40 |

--- a/exchange-rates/2025/09/05/central-money-exchange-20250905T032257835/request.json
+++ b/exchange-rates/2025/09/05/central-money-exchange-20250905T032257835/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-05T03:22:57.835509-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-05",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.32.1), 15 hops max\n  1   140.204.227.49  0.270ms  0.144ms  0.131ms \n  2   140.204.28.36  11.617ms  11.571ms  11.601ms \n  3   *  *  * \n  4   141.101.72.31  9.195ms  8.816ms  9.715ms \n  5   104.21.32.1  10.583ms  10.532ms  10.550ms \n"
+}

--- a/exchange-rates/2025/09/05/central-money-exchange-20250905T032257835/response.json
+++ b/exchange-rates/2025/09/05/central-money-exchange-20250905T032257835/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Fri, 05 Sep 2025 06:33:26 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=CPArmrDK95WD%2BYIMm0w%2FHAIo3vPA8TkPYmxw5A0n1N%2Bzje8ixurJNtQffMcmMeHvFsEn7dTw2Fa0tPjSh9mWAS5B0xvD2v3ElKg%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97a3b1efa8f1b8bd-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7000,\"SaleUsdExchangeRate\":38.5000,\"SaleEuroExchangeRate\":44.4000,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"05-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"03:33 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/05/central-money-exchange-20250905T032257835/results.json
+++ b/exchange-rates/2025/09/05/central-money-exchange-20250905T032257835/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.50",
+    "updated_on": "2025-09-05",
+    "updated_on_time": "03:33 AM"
+  },
+  "EUR": {
+    "buy": "43.70",
+    "sell": "44.40",
+    "updated_on": "2025-09-05",
+    "updated_on_time": "03:33 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/05/central-money-exchange-20250905T032257835) in the repository.