### PR TITLE
Central Money Exchange - September 5, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/05/central-money-exchange-20250905T084639912/README.md
+++ b/exchange-rates/2025/09/05/central-money-exchange-20250905T084639912/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-05 08:46:39
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-05 |
+| Method | POST |
+| Timestamp | 2025-09-05T08:46:39.912570-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Fri, 05 Sep 2025 11:56:36 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=6Jz50GXrqikIzxcZmueilwtO34b2%2BN%2BBfS03XiJJbR%2FpnnhmBDV0P%2BAp08%2BylXzArdmMKgj59IRY%2BNlbo9HFCsmoGpuqIk48"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97a58b4fbc3cf207-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.64.1), 15 hops max
+  1   140.204.226.195  0.187ms  0.114ms  0.114ms 
+  2   140.204.28.36  11.832ms  11.536ms  11.536ms 
+  3   *  140.204.28.37  12.229ms  * 
+  4   141.101.72.83  12.608ms  12.024ms  12.113ms 
+  5   104.21.64.1  11.953ms  11.882ms  11.921ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.50 |
+| EUR | 43.85 | 44.65 |

--- a/exchange-rates/2025/09/05/central-money-exchange-20250905T084639912/request.json
+++ b/exchange-rates/2025/09/05/central-money-exchange-20250905T084639912/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-05T08:46:39.912570-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-05",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.64.1), 15 hops max\n  1   140.204.226.195  0.187ms  0.114ms  0.114ms \n  2   140.204.28.36  11.832ms  11.536ms  11.536ms \n  3   *  140.204.28.37  12.229ms  * \n  4   141.101.72.83  12.608ms  12.024ms  12.113ms \n  5   104.21.64.1  11.953ms  11.882ms  11.921ms \n"
+}

--- a/exchange-rates/2025/09/05/central-money-exchange-20250905T084639912/response.json
+++ b/exchange-rates/2025/09/05/central-money-exchange-20250905T084639912/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Fri, 05 Sep 2025 11:56:36 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=6Jz50GXrqikIzxcZmueilwtO34b2%2BN%2BBfS03XiJJbR%2FpnnhmBDV0P%2BAp08%2BylXzArdmMKgj59IRY%2BNlbo9HFCsmoGpuqIk48\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97a58b4fbc3cf207-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.8500,\"SaleUsdExchangeRate\":38.5000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"05-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"08:56 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/05/central-money-exchange-20250905T084639912/results.json
+++ b/exchange-rates/2025/09/05/central-money-exchange-20250905T084639912/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.50",
+    "updated_on": "2025-09-05",
+    "updated_on_time": "08:56 AM"
+  },
+  "EUR": {
+    "buy": "43.85",
+    "sell": "44.65",
+    "updated_on": "2025-09-05",
+    "updated_on_time": "08:56 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/05/central-money-exchange-20250905T084639912) in the repository.