### PR TITLE
Central Money Exchange - September 6, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T005816066/README.md
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T005816066/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-06 00:58:16
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-06 |
+| Method | POST |
+| Timestamp | 2025-09-06T00:58:16.066449-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sat, 06 Sep 2025 04:09:14 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=IbAyVpWEcSDuaL2bl%2FMW5X3rqWK1XqS7eNiB6GZd%2FYud6G9MsZZnKsjrSxWa31ewziGcydS2w0%2FdIM1MdYxPaFeKXcg0Fyeb"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97ab1c138ebed90f-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.16.1), 15 hops max
+  1   140.91.195.16  0.262ms  0.176ms  0.134ms 
+  2   140.204.28.36  10.257ms  12.018ms  20.259ms 
+  3   140.204.28.37  12.253ms  *  * 
+  4   141.101.72.87  13.575ms  12.272ms  12.182ms 
+  5   104.21.16.1  9.064ms  9.043ms  9.016ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.50 |
+| EUR | 44.00 | 44.65 |

--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T005816066/request.json
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T005816066/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-06T00:58:16.066449-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-06",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.16.1), 15 hops max\n  1   140.91.195.16  0.262ms  0.176ms  0.134ms \n  2   140.204.28.36  10.257ms  12.018ms  20.259ms \n  3   140.204.28.37  12.253ms  *  * \n  4   141.101.72.87  13.575ms  12.272ms  12.182ms \n  5   104.21.16.1  9.064ms  9.043ms  9.016ms \n"
+}

--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T005816066/response.json
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T005816066/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sat, 06 Sep 2025 04:09:14 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=IbAyVpWEcSDuaL2bl%2FMW5X3rqWK1XqS7eNiB6GZd%2FYud6G9MsZZnKsjrSxWa31ewziGcydS2w0%2FdIM1MdYxPaFeKXcg0Fyeb\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97ab1c138ebed90f-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":44.0000,\"SaleUsdExchangeRate\":38.5000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1150,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1150,\"Day\":null,\"BusinessDate\":\"06-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"01:09 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T005816066/results.json
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T005816066/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.50",
+    "updated_on": "2025-09-06",
+    "updated_on_time": "01:09 AM"
+  },
+  "EUR": {
+    "buy": "44.00",
+    "sell": "44.65",
+    "updated_on": "2025-09-06",
+    "updated_on_time": "01:09 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/06/central-money-exchange-20250906T005816066) in the repository.