### PR TITLE
Central Money Exchange - September 6, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T022006585/README.md
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T022006585/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-06 02:20:06
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-06 |
+| Method | POST |
+| Timestamp | 2025-09-06T02:20:06.585058-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sat, 06 Sep 2025 05:30:33 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=bxFfLnpq9EVfn6SO%2BjKWp0o%2FmQRiGqSHSPH%2BW%2FeMdzlhXVP1biQzZGRSJ2qpsQnIMlZxJWS6N9DGT8FHrz%2BhdYAK9ICPg%2FLW%2BQA%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97ab9331dbe19d92-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.48.1), 15 hops max
+  1   140.204.226.223  0.326ms  0.134ms  0.123ms 
+  2   140.204.28.36  10.018ms  10.074ms  10.257ms 
+  3   *  *  140.204.28.37  10.691ms 
+  4   141.101.72.83  9.061ms  9.716ms  9.791ms 
+  5   104.21.48.1  10.709ms  10.661ms  10.636ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.50 |
+| EUR | 44.00 | 44.65 |

--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T022006585/request.json
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T022006585/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-06T02:20:06.585058-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-06",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.48.1), 15 hops max\n  1   140.204.226.223  0.326ms  0.134ms  0.123ms \n  2   140.204.28.36  10.018ms  10.074ms  10.257ms \n  3   *  *  140.204.28.37  10.691ms \n  4   141.101.72.83  9.061ms  9.716ms  9.791ms \n  5   104.21.48.1  10.709ms  10.661ms  10.636ms \n"
+}

--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T022006585/response.json
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T022006585/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sat, 06 Sep 2025 05:30:33 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=bxFfLnpq9EVfn6SO%2BjKWp0o%2FmQRiGqSHSPH%2BW%2FeMdzlhXVP1biQzZGRSJ2qpsQnIMlZxJWS6N9DGT8FHrz%2BhdYAK9ICPg%2FLW%2BQA%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97ab9331dbe19d92-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":44.0000,\"SaleUsdExchangeRate\":38.5000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1150,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1150,\"Day\":null,\"BusinessDate\":\"06-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"02:30 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T022006585/results.json
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T022006585/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.50",
+    "updated_on": "2025-09-06",
+    "updated_on_time": "02:30 AM"
+  },
+  "EUR": {
+    "buy": "44.00",
+    "sell": "44.65",
+    "updated_on": "2025-09-06",
+    "updated_on_time": "02:30 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/06/central-money-exchange-20250906T022006585) in the repository.