### PR TITLE
Central Money Exchange - September 6, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T142610102/README.md
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T142610102/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-06 14:26:10
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-06 |
+| Method | POST |
+| Timestamp | 2025-09-06T14:26:10.102820-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sat, 06 Sep 2025 17:37:05 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=%2BDH%2FJbELUQsgPtGuBFIdYiG1g3xcDTquHKSyZjrFRqRzCuZP27q%2Fh%2FH5SuiApa0s0e0CFE43yjbiWbncxBcHFzwfEX4grOp97Zo%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97afbb754816e9e3-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.64.1), 15 hops max
+  1   140.204.227.49  0.201ms  0.076ms  0.118ms 
+  2   140.204.28.36  16.897ms  11.400ms  11.561ms 
+  3   *  *  140.204.28.37  10.798ms 
+  4   141.101.72.87  11.128ms  10.821ms  11.273ms 
+  5   104.21.64.1  12.206ms  12.179ms  12.144ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.75 | 38.70 |
+| EUR | 44.00 | 44.75 |

--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T142610102/request.json
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T142610102/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-06T14:26:10.102820-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-06",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.64.1), 15 hops max\n  1   140.204.227.49  0.201ms  0.076ms  0.118ms \n  2   140.204.28.36  16.897ms  11.400ms  11.561ms \n  3   *  *  140.204.28.37  10.798ms \n  4   141.101.72.87  11.128ms  10.821ms  11.273ms \n  5   104.21.64.1  12.206ms  12.179ms  12.144ms \n"
+}

--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T142610102/response.json
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T142610102/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sat, 06 Sep 2025 17:37:05 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=%2BDH%2FJbELUQsgPtGuBFIdYiG1g3xcDTquHKSyZjrFRqRzCuZP27q%2Fh%2FH5SuiApa0s0e0CFE43yjbiWbncxBcHFzwfEX4grOp97Zo%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97afbb754816e9e3-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7500,\"BuyEuroExchangeRate\":44.0000,\"SaleUsdExchangeRate\":38.7000,\"SaleEuroExchangeRate\":44.7500,\"ExchangeUsdRate\":1.1150,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1150,\"Day\":null,\"BusinessDate\":\"06-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"02:37 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/06/central-money-exchange-20250906T142610102/results.json
+++ b/exchange-rates/2025/09/06/central-money-exchange-20250906T142610102/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.75",
+    "sell": "38.70",
+    "updated_on": "2025-09-06",
+    "updated_on_time": "02:37 PM"
+  },
+  "EUR": {
+    "buy": "44.00",
+    "sell": "44.75",
+    "updated_on": "2025-09-06",
+    "updated_on_time": "02:37 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/06/central-money-exchange-20250906T142610102) in the repository.