### PR TITLE
Central Money Exchange - September 8, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/08/central-money-exchange-20250908T151009734/README.md
+++ b/exchange-rates/2025/09/08/central-money-exchange-20250908T151009734/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-08 15:10:09
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-08 |
+| Method | POST |
+| Timestamp | 2025-09-08T15:10:09.734444-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Mon, 08 Sep 2025 18:21:20 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=OfUBgGBcTtptiTsYBIKBVphHKsunUeixrdeygbFwW6tM64zkqD5iVAhtFHk31M2ML4AM8G7WCwJFU%2B1cqKtI0lf%2F4LCjEhsdI94%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97c07704ea95af67-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.80.1), 15 hops max
+  1   140.91.195.205  0.247ms  0.160ms  0.145ms 
+  2   140.204.28.36  10.127ms  9.902ms  9.902ms 
+  3   140.204.28.37  9.125ms  *  * 
+  4   141.101.72.21  11.588ms  11.167ms  11.269ms 
+  5   104.21.80.1  12.188ms  12.172ms  12.177ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.75 | 38.70 |
+| EUR | 44.00 | 44.75 |

--- a/exchange-rates/2025/09/08/central-money-exchange-20250908T151009734/request.json
+++ b/exchange-rates/2025/09/08/central-money-exchange-20250908T151009734/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-08T15:10:09.734444-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-08",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.80.1), 15 hops max\n  1   140.91.195.205  0.247ms  0.160ms  0.145ms \n  2   140.204.28.36  10.127ms  9.902ms  9.902ms \n  3   140.204.28.37  9.125ms  *  * \n  4   141.101.72.21  11.588ms  11.167ms  11.269ms \n  5   104.21.80.1  12.188ms  12.172ms  12.177ms \n"
+}

--- a/exchange-rates/2025/09/08/central-money-exchange-20250908T151009734/response.json
+++ b/exchange-rates/2025/09/08/central-money-exchange-20250908T151009734/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Mon, 08 Sep 2025 18:21:20 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=OfUBgGBcTtptiTsYBIKBVphHKsunUeixrdeygbFwW6tM64zkqD5iVAhtFHk31M2ML4AM8G7WCwJFU%2B1cqKtI0lf%2F4LCjEhsdI94%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97c07704ea95af67-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7500,\"BuyEuroExchangeRate\":44.0000,\"SaleUsdExchangeRate\":38.7000,\"SaleEuroExchangeRate\":44.7500,\"ExchangeUsdRate\":1.1150,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1150,\"Day\":null,\"BusinessDate\":\"08-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"03:21 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/08/central-money-exchange-20250908T151009734/results.json
+++ b/exchange-rates/2025/09/08/central-money-exchange-20250908T151009734/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.75",
+    "sell": "38.70",
+    "updated_on": "2025-09-08",
+    "updated_on_time": "03:21 PM"
+  },
+  "EUR": {
+    "buy": "44.00",
+    "sell": "44.75",
+    "updated_on": "2025-09-08",
+    "updated_on_time": "03:21 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/08/central-money-exchange-20250908T151009734) in the repository.