### PR TITLE
Central Money Exchange - September 9, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T114551678/README.md
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T114551678/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-09 11:45:51
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-09 |
+| Method | POST |
+| Timestamp | 2025-09-09T11:45:51.678370-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 09 Sep 2025 14:56:50 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=dvBOqCjudMhB5hEUagaDIeo%2FCxYhutPCv1YUg4F9cnTj7Yc1UeNGWhDNd4Di4CLGR8I45J3zuJEOdYACdJ7n9TGZa9uR9ZzccPI%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97c788d60e77e9dd-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.96.1), 15 hops max
+  1   140.204.226.249  0.157ms  0.115ms  0.108ms 
+  2   140.204.28.36  8.461ms  8.334ms  8.392ms 
+  3   140.204.28.37  13.606ms  *  10.357ms 
+  4   141.101.72.21  10.889ms  11.059ms  11.180ms 
+  5   104.21.96.1  10.413ms  10.358ms  9.963ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.00 | 38.80 |
+| EUR | 44.20 | 45.00 |

--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T114551678/request.json
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T114551678/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-09T11:45:51.678370-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-09",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.96.1), 15 hops max\n  1   140.204.226.249  0.157ms  0.115ms  0.108ms \n  2   140.204.28.36  8.461ms  8.334ms  8.392ms \n  3   140.204.28.37  13.606ms  *  10.357ms \n  4   141.101.72.21  10.889ms  11.059ms  11.180ms \n  5   104.21.96.1  10.413ms  10.358ms  9.963ms \n"
+}

--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T114551678/response.json
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T114551678/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 09 Sep 2025 14:56:50 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=dvBOqCjudMhB5hEUagaDIeo%2FCxYhutPCv1YUg4F9cnTj7Yc1UeNGWhDNd4Di4CLGR8I45J3zuJEOdYACdJ7n9TGZa9uR9ZzccPI%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97c788d60e77e9dd-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0000,\"BuyEuroExchangeRate\":44.2000,\"SaleUsdExchangeRate\":38.8000,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"09-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"11:56 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T114551678/results.json
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T114551678/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.00",
+    "sell": "38.80",
+    "updated_on": "2025-09-09",
+    "updated_on_time": "11:56 AM"
+  },
+  "EUR": {
+    "buy": "44.20",
+    "sell": "45.00",
+    "updated_on": "2025-09-09",
+    "updated_on_time": "11:56 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/09/central-money-exchange-20250909T114551678) in the repository.