### PR TITLE
Central Money Exchange - September 9, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T155110091/README.md
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T155110091/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-09 15:51:10
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-09 |
+| Method | POST |
+| Timestamp | 2025-09-09T15:51:10.091277-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 09 Sep 2025 19:02:37 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=ixmNvpKS4Ccyf259Ah452fEeBdRa4S5kCqGBExcEjQni4PM5TIJb19AX7othx4JGI5kYD76lJ3yzdbV2sxz2Ck52EuEIiKw88W8%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97c8f0e00c0cdb5e-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.112.1), 15 hops max
+  1   140.204.227.71  0.251ms  0.129ms  0.126ms 
+  2   140.204.28.36  11.873ms  11.696ms  11.568ms 
+  3   140.204.28.37  13.489ms  *  * 
+  4   141.101.72.31  15.752ms  17.057ms  20.963ms 
+  5   104.21.112.1  12.249ms  12.200ms  12.192ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.00 | 38.80 |
+| EUR | 44.20 | 45.00 |

--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T155110091/request.json
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T155110091/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-09T15:51:10.091277-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-09",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.112.1), 15 hops max\n  1   140.204.227.71  0.251ms  0.129ms  0.126ms \n  2   140.204.28.36  11.873ms  11.696ms  11.568ms \n  3   140.204.28.37  13.489ms  *  * \n  4   141.101.72.31  15.752ms  17.057ms  20.963ms \n  5   104.21.112.1  12.249ms  12.200ms  12.192ms \n"
+}

--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T155110091/response.json
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T155110091/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 09 Sep 2025 19:02:37 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=ixmNvpKS4Ccyf259Ah452fEeBdRa4S5kCqGBExcEjQni4PM5TIJb19AX7othx4JGI5kYD76lJ3yzdbV2sxz2Ck52EuEIiKw88W8%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97c8f0e00c0cdb5e-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0000,\"BuyEuroExchangeRate\":44.2000,\"SaleUsdExchangeRate\":38.8000,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"09-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"04:02 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T155110091/results.json
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T155110091/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.00",
+    "sell": "38.80",
+    "updated_on": "2025-09-09",
+    "updated_on_time": "04:02 PM"
+  },
+  "EUR": {
+    "buy": "44.20",
+    "sell": "45.00",
+    "updated_on": "2025-09-09",
+    "updated_on_time": "04:02 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/09/central-money-exchange-20250909T155110091) in the repository.