### PR TITLE
Central Money Exchange - September 9, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T183514257/README.md
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T183514257/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-09 18:35:14
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-09 |
+| Method | POST |
+| Timestamp | 2025-09-09T18:35:14.257868-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 09 Sep 2025 21:46:49 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=hhnjEKKpm39vHyO01S312nDC3OH0K5rEUBGMO%2FvXwKldRwPHuQfk68FZ9%2FfS2yNb%2BgOKsJ7VGT0MR9yX0R5y7SSFjjA%2FwRak8FA%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97c9e167f8efa609-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.48.1), 15 hops max
+  1   140.91.194.97  0.161ms  0.149ms  0.116ms 
+  2   140.204.28.36  10.174ms  10.096ms  10.060ms 
+  3   140.204.28.37  9.104ms  *  * 
+  4   141.101.72.34  26.852ms  21.775ms  20.017ms 
+  5   104.21.48.1  10.400ms  10.192ms  10.342ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.00 | 38.80 |
+| EUR | 44.20 | 45.00 |

--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T183514257/request.json
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T183514257/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-09T18:35:14.257868-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-09",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.48.1), 15 hops max\n  1   140.91.194.97  0.161ms  0.149ms  0.116ms \n  2   140.204.28.36  10.174ms  10.096ms  10.060ms \n  3   140.204.28.37  9.104ms  *  * \n  4   141.101.72.34  26.852ms  21.775ms  20.017ms \n  5   104.21.48.1  10.400ms  10.192ms  10.342ms \n"
+}

--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T183514257/response.json
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T183514257/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 09 Sep 2025 21:46:49 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=hhnjEKKpm39vHyO01S312nDC3OH0K5rEUBGMO%2FvXwKldRwPHuQfk68FZ9%2FfS2yNb%2BgOKsJ7VGT0MR9yX0R5y7SSFjjA%2FwRak8FA%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97c9e167f8efa609-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0000,\"BuyEuroExchangeRate\":44.2000,\"SaleUsdExchangeRate\":38.8000,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"09-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"06:46 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/09/central-money-exchange-20250909T183514257/results.json
+++ b/exchange-rates/2025/09/09/central-money-exchange-20250909T183514257/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.00",
+    "sell": "38.80",
+    "updated_on": "2025-09-09",
+    "updated_on_time": "06:46 PM"
+  },
+  "EUR": {
+    "buy": "44.20",
+    "sell": "45.00",
+    "updated_on": "2025-09-09",
+    "updated_on_time": "06:46 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/09/central-money-exchange-20250909T183514257) in the repository.