### PR TITLE
Central Money Exchange - September 11, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/11/central-money-exchange-20250911T015016058/README.md
+++ b/exchange-rates/2025/09/11/central-money-exchange-20250911T015016058/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-11 01:50:16
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-11 |
+| Method | POST |
+| Timestamp | 2025-09-11T01:50:16.058735-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 11 Sep 2025 05:01:11 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=OtVC2xeOTh5PLB%2B5pDHmFgnhk3a%2FEaj609nm3%2BpKyZ8ydVf2nOKH8oHqPEHz5k%2FxJQR%2FozoA5eH%2FWxkpTIfV2on2RmRafitvZH8%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97d49b0ffa9c502d-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.80.1), 15 hops max
+  1   140.91.194.21  0.323ms  0.284ms  0.104ms 
+  2   140.204.28.36  11.230ms  22.865ms  8.482ms 
+  3   140.204.28.37  12.225ms  *  12.253ms 
+  4   141.101.72.87  11.178ms  11.312ms  10.940ms 
+  5   104.21.80.1  10.417ms  10.426ms  10.372ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.05 | 38.85 |
+| EUR | 43.60 | 44.85 |

--- a/exchange-rates/2025/09/11/central-money-exchange-20250911T015016058/request.json
+++ b/exchange-rates/2025/09/11/central-money-exchange-20250911T015016058/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-11T01:50:16.058735-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-11",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.80.1), 15 hops max\n  1   140.91.194.21  0.323ms  0.284ms  0.104ms \n  2   140.204.28.36  11.230ms  22.865ms  8.482ms \n  3   140.204.28.37  12.225ms  *  12.253ms \n  4   141.101.72.87  11.178ms  11.312ms  10.940ms \n  5   104.21.80.1  10.417ms  10.426ms  10.372ms \n"
+}

--- a/exchange-rates/2025/09/11/central-money-exchange-20250911T015016058/response.json
+++ b/exchange-rates/2025/09/11/central-money-exchange-20250911T015016058/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 11 Sep 2025 05:01:11 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=OtVC2xeOTh5PLB%2B5pDHmFgnhk3a%2FEaj609nm3%2BpKyZ8ydVf2nOKH8oHqPEHz5k%2FxJQR%2FozoA5eH%2FWxkpTIfV2on2RmRafitvZH8%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97d49b0ffa9c502d-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0500,\"BuyEuroExchangeRate\":43.6000,\"SaleUsdExchangeRate\":38.8500,\"SaleEuroExchangeRate\":44.8500,\"ExchangeUsdRate\":1.1150,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1150,\"Day\":null,\"BusinessDate\":\"11-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"02:01 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/11/central-money-exchange-20250911T015016058/results.json
+++ b/exchange-rates/2025/09/11/central-money-exchange-20250911T015016058/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.05",
+    "sell": "38.85",
+    "updated_on": "2025-09-11",
+    "updated_on_time": "02:01 AM"
+  },
+  "EUR": {
+    "buy": "43.60",
+    "sell": "44.85",
+    "updated_on": "2025-09-11",
+    "updated_on_time": "02:01 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/11/central-money-exchange-20250911T015016058) in the repository.