### PR TITLE
Central Money Exchange - September 11, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/11/central-money-exchange-20250911T055417766/README.md
+++ b/exchange-rates/2025/09/11/central-money-exchange-20250911T055417766/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-11 05:54:17
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-11 |
+| Method | POST |
+| Timestamp | 2025-09-11T05:54:17.766974-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 11 Sep 2025 09:05:51 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=WjX9tmB5a5yU98DtYCpE2H87JDJNgWGK3alPsQTNRJeVvOASy2T88UEQD9negBXOHHM2jZwxWcHlXbIs1UO0tFVOWTnLyiUn83U%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97d60177fbff2f0e-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.80.1), 15 hops max
+  1   140.204.227.47  0.203ms  0.125ms  0.128ms 
+  2   140.204.28.36  29.075ms  8.611ms  8.379ms 
+  3   *  *  * 
+  4   141.101.72.87  11.017ms  10.540ms  17.264ms 
+  5   104.21.80.1  12.147ms  12.122ms  12.214ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.05 | 38.85 |
+| EUR | 43.60 | 44.85 |

--- a/exchange-rates/2025/09/11/central-money-exchange-20250911T055417766/request.json
+++ b/exchange-rates/2025/09/11/central-money-exchange-20250911T055417766/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-11T05:54:17.766974-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-11",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.80.1), 15 hops max\n  1   140.204.227.47  0.203ms  0.125ms  0.128ms \n  2   140.204.28.36  29.075ms  8.611ms  8.379ms \n  3   *  *  * \n  4   141.101.72.87  11.017ms  10.540ms  17.264ms \n  5   104.21.80.1  12.147ms  12.122ms  12.214ms \n"
+}

--- a/exchange-rates/2025/09/11/central-money-exchange-20250911T055417766/response.json
+++ b/exchange-rates/2025/09/11/central-money-exchange-20250911T055417766/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 11 Sep 2025 09:05:51 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=WjX9tmB5a5yU98DtYCpE2H87JDJNgWGK3alPsQTNRJeVvOASy2T88UEQD9negBXOHHM2jZwxWcHlXbIs1UO0tFVOWTnLyiUn83U%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97d60177fbff2f0e-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0500,\"BuyEuroExchangeRate\":43.6000,\"SaleUsdExchangeRate\":38.8500,\"SaleEuroExchangeRate\":44.8500,\"ExchangeUsdRate\":1.1150,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1150,\"Day\":null,\"BusinessDate\":\"11-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"06:05 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/11/central-money-exchange-20250911T055417766/results.json
+++ b/exchange-rates/2025/09/11/central-money-exchange-20250911T055417766/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.05",
+    "sell": "38.85",
+    "updated_on": "2025-09-11",
+    "updated_on_time": "06:05 AM"
+  },
+  "EUR": {
+    "buy": "43.60",
+    "sell": "44.85",
+    "updated_on": "2025-09-11",
+    "updated_on_time": "06:05 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/11/central-money-exchange-20250911T055417766) in the repository.