### PR TITLE
Central Money Exchange - September 12, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T050706581/README.md
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T050706581/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-12 05:07:06
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-12 |
+| Method | POST |
+| Timestamp | 2025-09-12T05:07:06.581939-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Fri, 12 Sep 2025 08:18:02 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=G3Zv8KDdj9KDJr8es7jgTLHdtkZQ66t0RdRto%2Bp73f%2FVz6rV%2FbhbiJU0GJHTxwN3oQVapM48EI8Wd17FCCWICwjwpu3S9E8raJI%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97ddf8c7af602283-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.32.1), 15 hops max
+  1   140.204.227.25  0.206ms  0.126ms  0.168ms 
+  2   140.204.28.36  9.970ms  10.285ms  10.303ms 
+  3   *  140.204.28.37  10.554ms  10.471ms 
+  4   141.101.72.83  10.727ms  11.325ms  10.591ms 
+  5   104.21.32.1  10.630ms  10.523ms  10.540ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.05 | 38.85 |
+| EUR | 43.70 | 44.65 |

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T050706581/request.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T050706581/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-12T05:07:06.581939-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-12",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.32.1), 15 hops max\n  1   140.204.227.25  0.206ms  0.126ms  0.168ms \n  2   140.204.28.36  9.970ms  10.285ms  10.303ms \n  3   *  140.204.28.37  10.554ms  10.471ms \n  4   141.101.72.83  10.727ms  11.325ms  10.591ms \n  5   104.21.32.1  10.630ms  10.523ms  10.540ms \n"
+}

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T050706581/response.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T050706581/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Fri, 12 Sep 2025 08:18:02 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=G3Zv8KDdj9KDJr8es7jgTLHdtkZQ66t0RdRto%2Bp73f%2FVz6rV%2FbhbiJU0GJHTxwN3oQVapM48EI8Wd17FCCWICwjwpu3S9E8raJI%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97ddf8c7af602283-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0500,\"BuyEuroExchangeRate\":43.7000,\"SaleUsdExchangeRate\":38.8500,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1400,\"ExchangeUsdRateNew\":1.1400,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"12-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"05:18 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T050706581/results.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T050706581/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.05",
+    "sell": "38.85",
+    "updated_on": "2025-09-12",
+    "updated_on_time": "05:18 AM"
+  },
+  "EUR": {
+    "buy": "43.70",
+    "sell": "44.65",
+    "updated_on": "2025-09-12",
+    "updated_on_time": "05:18 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/12/central-money-exchange-20250912T050706581) in the repository.