### PR TITLE
Central Money Exchange - September 12, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T103408671/README.md
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T103408671/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-12 10:34:08
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-12 |
+| Method | POST |
+| Timestamp | 2025-09-12T10:34:08.671535-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Fri, 12 Sep 2025 13:45:44 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=9AFxiJrqDVtihopCx4yxxuOAcdpich8v9WSrH7fcSSmxvf4vL19S0XfFXwjxOpz%2BvrvclK%2BkJcbsl3dCYbhVdK4o%2FDMG%2FjnFkqg%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97dfd8d4080be9e1-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.96.1), 15 hops max
+  1   140.91.194.103  0.211ms  0.110ms  0.123ms 
+  2   140.204.28.36  49.783ms  72.722ms  10.053ms 
+  3   140.204.28.37  10.326ms  *  11.095ms 
+  4   141.101.72.27  12.662ms  26.894ms  21.924ms 
+  5   104.21.96.1  10.914ms  10.738ms  10.700ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.05 | 38.85 |
+| EUR | 43.25 | 44.65 |

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T103408671/request.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T103408671/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-12T10:34:08.671535-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-12",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.96.1), 15 hops max\n  1   140.91.194.103  0.211ms  0.110ms  0.123ms \n  2   140.204.28.36  49.783ms  72.722ms  10.053ms \n  3   140.204.28.37  10.326ms  *  11.095ms \n  4   141.101.72.27  12.662ms  26.894ms  21.924ms \n  5   104.21.96.1  10.914ms  10.738ms  10.700ms \n"
+}

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T103408671/response.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T103408671/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Fri, 12 Sep 2025 13:45:44 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=9AFxiJrqDVtihopCx4yxxuOAcdpich8v9WSrH7fcSSmxvf4vL19S0XfFXwjxOpz%2BvrvclK%2BkJcbsl3dCYbhVdK4o%2FDMG%2FjnFkqg%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97dfd8d4080be9e1-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0500,\"BuyEuroExchangeRate\":43.2500,\"SaleUsdExchangeRate\":38.8500,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1400,\"ExchangeUsdRateNew\":1.1400,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"12-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"10:45 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T103408671/results.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T103408671/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.05",
+    "sell": "38.85",
+    "updated_on": "2025-09-12",
+    "updated_on_time": "10:45 AM"
+  },
+  "EUR": {
+    "buy": "43.25",
+    "sell": "44.65",
+    "updated_on": "2025-09-12",
+    "updated_on_time": "10:45 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/12/central-money-exchange-20250912T103408671) in the repository.