### PR TITLE
Central Money Exchange - September 12, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T131919701/README.md
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T131919701/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-12 13:19:19
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-12 |
+| Method | POST |
+| Timestamp | 2025-09-12T13:19:19.701964-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Fri, 12 Sep 2025 16:30:18 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=uETxpmMkKJFVhDOSOhGSH1rlwSo%2FKLzPYJi%2FsdyGRp614Tt03qGLaFv4ClnO753KjgNrTlG2X6RISXZeQhNwudJ9zzsLPqObHlY%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97e0c9e03d3e1038-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.16.1), 15 hops max
+  1   140.204.226.197  0.596ms  0.353ms  * 
+  2   140.204.28.36  11.660ms  11.751ms  11.903ms 
+  3   *  *  * 
+  4   141.101.72.83  19.858ms  15.035ms  17.795ms 
+  5   104.21.16.1  9.408ms  9.132ms  9.096ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.05 | 38.85 |
+| EUR | 43.25 | 44.65 |

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T131919701/request.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T131919701/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-12T13:19:19.701964-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-12",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.16.1), 15 hops max\n  1   140.204.226.197  0.596ms  0.353ms  * \n  2   140.204.28.36  11.660ms  11.751ms  11.903ms \n  3   *  *  * \n  4   141.101.72.83  19.858ms  15.035ms  17.795ms \n  5   104.21.16.1  9.408ms  9.132ms  9.096ms \n"
+}

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T131919701/response.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T131919701/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Fri, 12 Sep 2025 16:30:18 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=uETxpmMkKJFVhDOSOhGSH1rlwSo%2FKLzPYJi%2FsdyGRp614Tt03qGLaFv4ClnO753KjgNrTlG2X6RISXZeQhNwudJ9zzsLPqObHlY%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97e0c9e03d3e1038-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0500,\"BuyEuroExchangeRate\":43.2500,\"SaleUsdExchangeRate\":38.8500,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1400,\"ExchangeUsdRateNew\":1.1400,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"12-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"01:30 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T131919701/results.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T131919701/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.05",
+    "sell": "38.85",
+    "updated_on": "2025-09-12",
+    "updated_on_time": "01:30 PM"
+  },
+  "EUR": {
+    "buy": "43.25",
+    "sell": "44.65",
+    "updated_on": "2025-09-12",
+    "updated_on_time": "01:30 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/12/central-money-exchange-20250912T131919701) in the repository.