### PR TITLE
Central Money Exchange - September 12, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T212801648/README.md
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T212801648/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-12 21:28:01
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-12 |
+| Method | POST |
+| Timestamp | 2025-09-12T21:28:01.648406-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sat, 13 Sep 2025 00:39:58 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=B96SuHjN0bmaJxLQ1xF9310YmsIfV8Vt5167mz4DofkmguntrYrDoCIbV8jjZMIDoQwrjXTwHyOPY6UFFbpRlEU2lcSbDeaTDYA%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97e39728ffc3f7dd-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.64.1), 15 hops max
+  1   140.204.226.207  0.191ms  0.142ms  0.302ms 
+  2   140.204.28.36  10.124ms  10.205ms  10.160ms 
+  3   140.204.28.37  9.085ms  8.999ms  9.063ms 
+  4   141.101.72.31  31.227ms  10.230ms  10.173ms 
+  5   104.21.64.1  8.989ms  8.967ms  8.966ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.00 | 37.10 |
+| EUR | 43.10 | 44.45 |

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T212801648/request.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T212801648/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-12T21:28:01.648406-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-12",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.64.1), 15 hops max\n  1   140.204.226.207  0.191ms  0.142ms  0.302ms \n  2   140.204.28.36  10.124ms  10.205ms  10.160ms \n  3   140.204.28.37  9.085ms  8.999ms  9.063ms \n  4   141.101.72.31  31.227ms  10.230ms  10.173ms \n  5   104.21.64.1  8.989ms  8.967ms  8.966ms \n"
+}

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T212801648/response.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T212801648/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sat, 13 Sep 2025 00:39:58 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=B96SuHjN0bmaJxLQ1xF9310YmsIfV8Vt5167mz4DofkmguntrYrDoCIbV8jjZMIDoQwrjXTwHyOPY6UFFbpRlEU2lcSbDeaTDYA%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97e39728ffc3f7dd-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.0000,\"BuyEuroExchangeRate\":43.1000,\"SaleUsdExchangeRate\":37.1000,\"SaleEuroExchangeRate\":44.4500,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1400,\"ExchangeUsdRateNew\":1.1400,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"12-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"09:39 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/12/central-money-exchange-20250912T212801648/results.json
+++ b/exchange-rates/2025/09/12/central-money-exchange-20250912T212801648/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.00",
+    "sell": "37.10",
+    "updated_on": "2025-09-12",
+    "updated_on_time": "09:39 PM"
+  },
+  "EUR": {
+    "buy": "43.10",
+    "sell": "44.45",
+    "updated_on": "2025-09-12",
+    "updated_on_time": "09:39 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/12/central-money-exchange-20250912T212801648) in the repository.