### PR TITLE
Central Money Exchange - September 14, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/14/central-money-exchange-20250914T031830100/README.md
+++ b/exchange-rates/2025/09/14/central-money-exchange-20250914T031830100/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-14 03:18:30
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-14 |
+| Method | POST |
+| Timestamp | 2025-09-14T03:18:30.100722-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sun, 14 Sep 2025 06:29:34 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=xVFnpCBZPEU8wFbUa3ZqsxuvR2eeVNnqxPiiVNvsW1wZ%2BSRDXgMqKZ8%2F2Vxie0J5MCvtfkG1U137%2F%2BKckUlQHEWaMTVlBPRodIg%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97edd4a7ac8308b2-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.64.1), 15 hops max
+  1   140.204.226.207  0.197ms  0.157ms  0.146ms 
+  2   140.204.28.36  10.212ms  9.970ms  10.779ms 
+  3   140.204.28.37  10.553ms  11.373ms  10.477ms 
+  4   141.101.72.31  14.768ms  17.799ms  18.865ms 
+  5   104.21.64.1  9.000ms  8.974ms  8.953ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.65 | 39.15 |
+| EUR | 43.35 | 44.45 |

--- a/exchange-rates/2025/09/14/central-money-exchange-20250914T031830100/request.json
+++ b/exchange-rates/2025/09/14/central-money-exchange-20250914T031830100/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-14T03:18:30.100722-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-14",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.64.1), 15 hops max\n  1   140.204.226.207  0.197ms  0.157ms  0.146ms \n  2   140.204.28.36  10.212ms  9.970ms  10.779ms \n  3   140.204.28.37  10.553ms  11.373ms  10.477ms \n  4   141.101.72.31  14.768ms  17.799ms  18.865ms \n  5   104.21.64.1  9.000ms  8.974ms  8.953ms \n"
+}

--- a/exchange-rates/2025/09/14/central-money-exchange-20250914T031830100/response.json
+++ b/exchange-rates/2025/09/14/central-money-exchange-20250914T031830100/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sun, 14 Sep 2025 06:29:34 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=xVFnpCBZPEU8wFbUa3ZqsxuvR2eeVNnqxPiiVNvsW1wZ%2BSRDXgMqKZ8%2F2Vxie0J5MCvtfkG1U137%2F%2BKckUlQHEWaMTVlBPRodIg%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97edd4a7ac8308b2-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.6500,\"BuyEuroExchangeRate\":43.3500,\"SaleUsdExchangeRate\":39.1500,\"SaleEuroExchangeRate\":44.4500,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1400,\"ExchangeUsdRateNew\":1.1400,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"14-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"03:29 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/14/central-money-exchange-20250914T031830100/results.json
+++ b/exchange-rates/2025/09/14/central-money-exchange-20250914T031830100/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.65",
+    "sell": "39.15",
+    "updated_on": "2025-09-14",
+    "updated_on_time": "03:29 AM"
+  },
+  "EUR": {
+    "buy": "43.35",
+    "sell": "44.45",
+    "updated_on": "2025-09-14",
+    "updated_on_time": "03:29 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/14/central-money-exchange-20250914T031830100) in the repository.