### PR TITLE
Central Money Exchange - September 14, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/14/central-money-exchange-20250914T181447347/README.md
+++ b/exchange-rates/2025/09/14/central-money-exchange-20250914T181447347/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-14 18:14:47
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-14 |
+| Method | POST |
+| Timestamp | 2025-09-14T18:14:47.347336-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sun, 14 Sep 2025 21:25:43 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=xv0S%2BTliLORimgkv4QkSMmIxDiLusSpztYWAFX5FqZB%2FVtaA2oG2Lw7VtY%2FiVW4ehX3LnJxeNygM4P8bwJvzz9fVTcYsGz%2BN1h0%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97f2f5605b830fe5-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.80.1), 15 hops max
+  1   140.204.226.225  0.183ms  0.206ms  0.120ms 
+  2   140.204.28.36  11.593ms  11.697ms  11.680ms 
+  3   140.204.28.37  12.140ms  *  12.655ms 
+  4   141.101.72.31  28.683ms  21.624ms  20.665ms 
+  5   104.21.80.1  8.954ms  8.926ms  9.136ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.65 | 39.15 |
+| EUR | 43.35 | 44.45 |

--- a/exchange-rates/2025/09/14/central-money-exchange-20250914T181447347/request.json
+++ b/exchange-rates/2025/09/14/central-money-exchange-20250914T181447347/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-14T18:14:47.347336-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-14",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.80.1), 15 hops max\n  1   140.204.226.225  0.183ms  0.206ms  0.120ms \n  2   140.204.28.36  11.593ms  11.697ms  11.680ms \n  3   140.204.28.37  12.140ms  *  12.655ms \n  4   141.101.72.31  28.683ms  21.624ms  20.665ms \n  5   104.21.80.1  8.954ms  8.926ms  9.136ms \n"
+}

--- a/exchange-rates/2025/09/14/central-money-exchange-20250914T181447347/response.json
+++ b/exchange-rates/2025/09/14/central-money-exchange-20250914T181447347/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sun, 14 Sep 2025 21:25:43 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=xv0S%2BTliLORimgkv4QkSMmIxDiLusSpztYWAFX5FqZB%2FVtaA2oG2Lw7VtY%2FiVW4ehX3LnJxeNygM4P8bwJvzz9fVTcYsGz%2BN1h0%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97f2f5605b830fe5-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.6500,\"BuyEuroExchangeRate\":43.3500,\"SaleUsdExchangeRate\":39.1500,\"SaleEuroExchangeRate\":44.4500,\"ExchangeUsdRate\":1.1100,\"ExchangeEuroRate\":1.1400,\"ExchangeUsdRateNew\":1.1400,\"ExchangeEuroRateNew\":1.1100,\"Day\":null,\"BusinessDate\":\"14-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"06:25 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/14/central-money-exchange-20250914T181447347/results.json
+++ b/exchange-rates/2025/09/14/central-money-exchange-20250914T181447347/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.65",
+    "sell": "39.15",
+    "updated_on": "2025-09-14",
+    "updated_on_time": "06:25 PM"
+  },
+  "EUR": {
+    "buy": "43.35",
+    "sell": "44.45",
+    "updated_on": "2025-09-14",
+    "updated_on_time": "06:25 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/14/central-money-exchange-20250914T181447347) in the repository.