### PR TITLE
Central Money Exchange - September 15, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/15/central-money-exchange-20250915T212950419/README.md
+++ b/exchange-rates/2025/09/15/central-money-exchange-20250915T212950419/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-15 21:29:50
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-15 |
+| Method | POST |
+| Timestamp | 2025-09-15T21:29:50.419391-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 16 Sep 2025 00:40:49 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=lRnzyWJG5r5dLmoReJEYqdTDqmVmbPU%2Fqz8ZZpBlb%2FUB3sYLQROIeLFwDgbUGZF8C%2FdaluUZl7Ajcf0GYyFuhYJYVfXocx%2Fx"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97fc50819c5ef208-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.16.1), 15 hops max
+  1   140.204.227.57  0.247ms  0.131ms  0.129ms 
+  2   140.204.28.36  9.930ms  10.998ms  9.880ms 
+  3   *  140.204.28.37  15.590ms  * 
+  4   141.101.72.27  12.723ms  10.761ms  11.029ms 
+  5   *  104.21.16.1  12.178ms  12.096ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.00 | 39.15 |
+| EUR | 43.35 | 44.65 |

--- a/exchange-rates/2025/09/15/central-money-exchange-20250915T212950419/request.json
+++ b/exchange-rates/2025/09/15/central-money-exchange-20250915T212950419/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-15T21:29:50.419391-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-15",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.16.1), 15 hops max\n  1   140.204.227.57  0.247ms  0.131ms  0.129ms \n  2   140.204.28.36  9.930ms  10.998ms  9.880ms \n  3   *  140.204.28.37  15.590ms  * \n  4   141.101.72.27  12.723ms  10.761ms  11.029ms \n  5   *  104.21.16.1  12.178ms  12.096ms \n"
+}

--- a/exchange-rates/2025/09/15/central-money-exchange-20250915T212950419/response.json
+++ b/exchange-rates/2025/09/15/central-money-exchange-20250915T212950419/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 16 Sep 2025 00:40:49 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=lRnzyWJG5r5dLmoReJEYqdTDqmVmbPU%2Fqz8ZZpBlb%2FUB3sYLQROIeLFwDgbUGZF8C%2FdaluUZl7Ajcf0GYyFuhYJYVfXocx%2Fx\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97fc50819c5ef208-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0000,\"BuyEuroExchangeRate\":43.3500,\"SaleUsdExchangeRate\":39.1500,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1150,\"ExchangeEuroRate\":1.1400,\"ExchangeUsdRateNew\":1.1400,\"ExchangeEuroRateNew\":1.1150,\"Day\":null,\"BusinessDate\":\"15-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"09:40 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/15/central-money-exchange-20250915T212950419/results.json
+++ b/exchange-rates/2025/09/15/central-money-exchange-20250915T212950419/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.00",
+    "sell": "39.15",
+    "updated_on": "2025-09-15",
+    "updated_on_time": "09:40 PM"
+  },
+  "EUR": {
+    "buy": "43.35",
+    "sell": "44.65",
+    "updated_on": "2025-09-15",
+    "updated_on_time": "09:40 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/15/central-money-exchange-20250915T212950419) in the repository.