### PR TITLE
Central Money Exchange - September 16, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T001340124/README.md
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T001340124/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-16 00:13:40
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16 |
+| Method | POST |
+| Timestamp | 2025-09-16T00:13:40.124046-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 16 Sep 2025 03:24:35 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=yZbMwPel3YUoLxhHX2PWP%2Fh8v4Q3HUqVhv176NlJjdOEQ1Onvt0w6D%2F%2Bzisl%2BUnw0Yvv3CQypDF2DfNIfDah%2F%2F0C7%2BlvRTdeT6M%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97fd406e2ecef7df-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.16.1), 15 hops max
+  1   140.204.226.199  0.258ms  0.144ms  0.153ms 
+  2   140.204.28.36  13.272ms  11.667ms  11.692ms 
+  3   140.204.28.37  9.353ms  *  9.083ms 
+  4   141.101.72.87  12.880ms  12.832ms  12.213ms 
+  5   104.21.16.1  10.437ms  10.552ms  10.874ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.00 | 39.15 |
+| EUR | 43.35 | 44.65 |

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T001340124/request.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T001340124/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-16T00:13:40.124046-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.16.1), 15 hops max\n  1   140.204.226.199  0.258ms  0.144ms  0.153ms \n  2   140.204.28.36  13.272ms  11.667ms  11.692ms \n  3   140.204.28.37  9.353ms  *  9.083ms \n  4   141.101.72.87  12.880ms  12.832ms  12.213ms \n  5   104.21.16.1  10.437ms  10.552ms  10.874ms \n"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T001340124/response.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T001340124/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 16 Sep 2025 03:24:35 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=yZbMwPel3YUoLxhHX2PWP%2Fh8v4Q3HUqVhv176NlJjdOEQ1Onvt0w6D%2F%2Bzisl%2BUnw0Yvv3CQypDF2DfNIfDah%2F%2F0C7%2BlvRTdeT6M%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97fd406e2ecef7df-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0000,\"BuyEuroExchangeRate\":43.3500,\"SaleUsdExchangeRate\":39.1500,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1150,\"ExchangeEuroRate\":1.1400,\"ExchangeUsdRateNew\":1.1400,\"ExchangeEuroRateNew\":1.1150,\"Day\":null,\"BusinessDate\":\"16-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"12:24 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T001340124/results.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T001340124/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.00",
+    "sell": "39.15",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "12:24 AM"
+  },
+  "EUR": {
+    "buy": "43.35",
+    "sell": "44.65",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "12:24 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/16/central-money-exchange-20250916T001340124) in the repository.