### PR TITLE
Central Money Exchange - September 16, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T013501965/README.md
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T013501965/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-16 01:35:01
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16 |
+| Method | POST |
+| Timestamp | 2025-09-16T01:35:01.965165-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 16 Sep 2025 04:46:34 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=8WbYvfr%2FZGdff%2Fs3lgz%2FOgrzrN2sBDRHe0rWEQneBpXcr%2FIdvNECQYYiEIPRIki30r6sr%2BnYGWjVipdjzZrHpRVMLC%2FN5pi%2BD8U%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 97fdb886ef57cb8e-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.32.1), 15 hops max
+  1   140.204.227.67  0.297ms  0.129ms  0.162ms 
+  2   140.204.28.36  11.746ms  11.757ms  11.806ms 
+  3   140.204.28.37  10.706ms  *  11.220ms 
+  4   141.101.72.83  10.600ms  10.499ms  10.934ms 
+  5   104.21.32.1  9.040ms  9.004ms  8.996ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 38.00 | 39.15 |
+| EUR | 43.35 | 44.65 |

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T013501965/request.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T013501965/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-16T01:35:01.965165-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.32.1), 15 hops max\n  1   140.204.227.67  0.297ms  0.129ms  0.162ms \n  2   140.204.28.36  11.746ms  11.757ms  11.806ms \n  3   140.204.28.37  10.706ms  *  11.220ms \n  4   141.101.72.83  10.600ms  10.499ms  10.934ms \n  5   104.21.32.1  9.040ms  9.004ms  8.996ms \n"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T013501965/response.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T013501965/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 16 Sep 2025 04:46:34 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=8WbYvfr%2FZGdff%2Fs3lgz%2FOgrzrN2sBDRHe0rWEQneBpXcr%2FIdvNECQYYiEIPRIki30r6sr%2BnYGWjVipdjzZrHpRVMLC%2FN5pi%2BD8U%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "97fdb886ef57cb8e-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":38.0000,\"BuyEuroExchangeRate\":43.3500,\"SaleUsdExchangeRate\":39.1500,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1150,\"ExchangeEuroRate\":1.1400,\"ExchangeUsdRateNew\":1.1400,\"ExchangeEuroRateNew\":1.1150,\"Day\":null,\"BusinessDate\":\"16-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"01:46 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T013501965/results.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T013501965/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "38.00",
+    "sell": "39.15",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "01:46 AM"
+  },
+  "EUR": {
+    "buy": "43.35",
+    "sell": "44.65",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "01:46 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/16/central-money-exchange-20250916T013501965) in the repository.