### PR TITLE
Central Money Exchange - September 16, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T082440100/README.md
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T082440100/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-16 08:24:40
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16 |
+| Method | POST |
+| Timestamp | 2025-09-16T08:24:40.100689-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 16 Sep 2025 11:36:07 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=CMi6bhSRYR%2FqnI%2BXTwqfWdUmfJpl%2FaZv2Bzqw87G8LmJpVbBk14CtDZBCa1hn%2FrKVzs0%2BP0cHzI4Q33nMhRbTRCSJV%2B6AusqXZc%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98001071ef7f4adb-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.16.1), 15 hops max
+  1   140.91.194.21  0.302ms  0.155ms  0.152ms 
+  2   140.204.28.36  10.071ms  10.261ms  10.072ms 
+  3   140.204.28.37  9.430ms  9.225ms  9.166ms 
+  4   141.101.72.21  16.719ms  20.981ms  12.605ms 
+  5   104.21.16.1  12.205ms  12.159ms  12.187ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.50 | 38.30 |
+| EUR | 43.90 | 44.95 |

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T082440100/request.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T082440100/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-16T08:24:40.100689-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.16.1), 15 hops max\n  1   140.91.194.21  0.302ms  0.155ms  0.152ms \n  2   140.204.28.36  10.071ms  10.261ms  10.072ms \n  3   140.204.28.37  9.430ms  9.225ms  9.166ms \n  4   141.101.72.21  16.719ms  20.981ms  12.605ms \n  5   104.21.16.1  12.205ms  12.159ms  12.187ms \n"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T082440100/response.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T082440100/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 16 Sep 2025 11:36:07 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=CMi6bhSRYR%2FqnI%2BXTwqfWdUmfJpl%2FaZv2Bzqw87G8LmJpVbBk14CtDZBCa1hn%2FrKVzs0%2BP0cHzI4Q33nMhRbTRCSJV%2B6AusqXZc%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98001071ef7f4adb-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5000,\"BuyEuroExchangeRate\":43.9000,\"SaleUsdExchangeRate\":38.3000,\"SaleEuroExchangeRate\":44.9500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"16-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"08:36 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T082440100/results.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T082440100/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.50",
+    "sell": "38.30",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "08:36 AM"
+  },
+  "EUR": {
+    "buy": "43.90",
+    "sell": "44.95",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "08:36 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/16/central-money-exchange-20250916T082440100) in the repository.