### PR TITLE
Central Money Exchange - September 16, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T220349752/README.md
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T220349752/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-16 22:03:49
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16 |
+| Method | POST |
+| Timestamp | 2025-09-16T22:03:49.752568-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 17 Sep 2025 01:14:46 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=R%2BFC6d26SY3JKWcMt7EyoKuyO2QUBcysLCxdBhzwdSXsr7G9AX1QZK4X0tP5nhma7t39zZXocIB3gzQJ3szE55m7WBYcn8JIvho%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 9804bfa54e4d4adb-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.32.1), 15 hops max
+  1   140.204.226.205  0.330ms  0.334ms  0.320ms 
+  2   140.204.28.36  10.219ms  10.216ms  10.106ms 
+  3   140.204.28.37  15.739ms  23.942ms  * 
+  4   141.101.72.83  10.991ms  10.641ms  10.824ms 
+  5   104.21.32.1  12.093ms  12.061ms  12.401ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.50 | 38.30 |
+| EUR | 44.00 | 44.95 |

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T220349752/request.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T220349752/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-16T22:03:49.752568-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.32.1), 15 hops max\n  1   140.204.226.205  0.330ms  0.334ms  0.320ms \n  2   140.204.28.36  10.219ms  10.216ms  10.106ms \n  3   140.204.28.37  15.739ms  23.942ms  * \n  4   141.101.72.83  10.991ms  10.641ms  10.824ms \n  5   104.21.32.1  12.093ms  12.061ms  12.401ms \n"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T220349752/response.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T220349752/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 17 Sep 2025 01:14:46 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=R%2BFC6d26SY3JKWcMt7EyoKuyO2QUBcysLCxdBhzwdSXsr7G9AX1QZK4X0tP5nhma7t39zZXocIB3gzQJ3szE55m7WBYcn8JIvho%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "9804bfa54e4d4adb-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5000,\"BuyEuroExchangeRate\":44.0000,\"SaleUsdExchangeRate\":38.3000,\"SaleEuroExchangeRate\":44.9500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"16-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"10:14 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T220349752/results.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T220349752/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.50",
+    "sell": "38.30",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "10:14 PM"
+  },
+  "EUR": {
+    "buy": "44.00",
+    "sell": "44.95",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "10:14 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/16/central-money-exchange-20250916T220349752) in the repository.