### PR TITLE
Central Money Exchange - September 16, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T232550270/README.md
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T232550270/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-16 23:25:50
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16 |
+| Method | POST |
+| Timestamp | 2025-09-16T23:25:50.270499-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 17 Sep 2025 02:37:45 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=HaOSxIGbfQAnVvHyjZyhKdg7b0JYm6%2FHPIKmBII1sXhlvEw6di%2F3w9iFqfZXuxq3ZXq0mkQqXjvmYA7%2FiU4Y2AtAir2hBEcEPA4%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98053934db56d938-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.32.1), 15 hops max
+  1   140.204.227.21  0.387ms  0.158ms  0.161ms 
+  2   140.204.28.36  10.258ms  10.088ms  9.956ms 
+  3   140.204.28.37  12.129ms  12.142ms  * 
+  4   141.101.72.21  12.371ms  12.613ms  12.207ms 
+  5   104.21.32.1  12.143ms  12.051ms  12.022ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.50 | 38.30 |
+| EUR | 44.00 | 44.95 |

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T232550270/request.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T232550270/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-16T23:25:50.270499-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-16",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.32.1), 15 hops max\n  1   140.204.227.21  0.387ms  0.158ms  0.161ms \n  2   140.204.28.36  10.258ms  10.088ms  9.956ms \n  3   140.204.28.37  12.129ms  12.142ms  * \n  4   141.101.72.21  12.371ms  12.613ms  12.207ms \n  5   104.21.32.1  12.143ms  12.051ms  12.022ms \n"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T232550270/response.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T232550270/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 17 Sep 2025 02:37:45 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=HaOSxIGbfQAnVvHyjZyhKdg7b0JYm6%2FHPIKmBII1sXhlvEw6di%2F3w9iFqfZXuxq3ZXq0mkQqXjvmYA7%2FiU4Y2AtAir2hBEcEPA4%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98053934db56d938-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5000,\"BuyEuroExchangeRate\":44.0000,\"SaleUsdExchangeRate\":38.3000,\"SaleEuroExchangeRate\":44.9500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"16-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"11:37 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/16/central-money-exchange-20250916T232550270/results.json
+++ b/exchange-rates/2025/09/16/central-money-exchange-20250916T232550270/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.50",
+    "sell": "38.30",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "11:37 PM"
+  },
+  "EUR": {
+    "buy": "44.00",
+    "sell": "44.95",
+    "updated_on": "2025-09-16",
+    "updated_on_time": "11:37 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/16/central-money-exchange-20250916T232550270) in the repository.