### PR TITLE
Central Money Exchange - September 17, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/17/central-money-exchange-20250917T171151934/README.md
+++ b/exchange-rates/2025/09/17/central-money-exchange-20250917T171151934/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-17 17:11:51
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-17 |
+| Method | POST |
+| Timestamp | 2025-09-17T17:11:51.934747-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 17 Sep 2025 20:23:18 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=Cg8QWj%2FE7kZzduv7Ne%2Fn%2BIGkXixGD3gD2PeOLw2F7drw8k%2B3kQa1QIoe3L07ksoqP2Qe8gvk3YJ5aQNNCT8WutVIP4IBZ0Lxmbo%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 980b5213e8be08c7-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.204.227.7  0.399ms  0.187ms  0.338ms 
+  2   140.204.28.36  10.295ms  10.039ms  10.098ms 
+  3   140.204.28.37  11.354ms  *  * 
+  4   141.101.72.21  10.564ms  11.325ms  11.297ms 
+  5   104.21.95.5  12.066ms  12.038ms  12.076ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.75 | 38.15 |
+| EUR | 44.15 | 45.00 |

--- a/exchange-rates/2025/09/17/central-money-exchange-20250917T171151934/request.json
+++ b/exchange-rates/2025/09/17/central-money-exchange-20250917T171151934/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-17T17:11:51.934747-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-17",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.204.227.7  0.399ms  0.187ms  0.338ms \n  2   140.204.28.36  10.295ms  10.039ms  10.098ms \n  3   140.204.28.37  11.354ms  *  * \n  4   141.101.72.21  10.564ms  11.325ms  11.297ms \n  5   104.21.95.5  12.066ms  12.038ms  12.076ms \n"
+}

--- a/exchange-rates/2025/09/17/central-money-exchange-20250917T171151934/response.json
+++ b/exchange-rates/2025/09/17/central-money-exchange-20250917T171151934/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 17 Sep 2025 20:23:18 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=Cg8QWj%2FE7kZzduv7Ne%2Fn%2BIGkXixGD3gD2PeOLw2F7drw8k%2B3kQa1QIoe3L07ksoqP2Qe8gvk3YJ5aQNNCT8WutVIP4IBZ0Lxmbo%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "980b5213e8be08c7-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7500,\"BuyEuroExchangeRate\":44.1500,\"SaleUsdExchangeRate\":38.1500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"17-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"05:23 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/17/central-money-exchange-20250917T171151934/results.json
+++ b/exchange-rates/2025/09/17/central-money-exchange-20250917T171151934/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.75",
+    "sell": "38.15",
+    "updated_on": "2025-09-17",
+    "updated_on_time": "05:23 PM"
+  },
+  "EUR": {
+    "buy": "44.15",
+    "sell": "45.00",
+    "updated_on": "2025-09-17",
+    "updated_on_time": "05:23 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/17/central-money-exchange-20250917T171151934) in the repository.