### PR TITLE
Central Money Exchange - September 17, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/17/central-money-exchange-20250917T195650103/README.md
+++ b/exchange-rates/2025/09/17/central-money-exchange-20250917T195650103/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-17 19:56:50
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-17 |
+| Method | POST |
+| Timestamp | 2025-09-17T19:56:50.103012-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 17 Sep 2025 23:08:48 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=OpZX2fmVp1Gdcs%2BkhfgMqbYcDYLbQNva1HDzMoQQLD6eKLLh0FnuvPWtyr7%2BldYDjtpZ5W2eKXK4QqfeUmZEzMBi0ZRD0EsDs2g%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 980c44806ee8f4ef-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.204.227.39  0.257ms  0.257ms  0.135ms 
+  2   140.204.28.36  10.137ms  9.957ms  10.141ms 
+  3   140.204.28.37  11.350ms  *  10.555ms 
+  4   141.101.72.83  9.494ms  8.969ms  9.450ms 
+  5   104.21.95.5  10.402ms  10.456ms  10.451ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.75 | 38.15 |
+| EUR | 44.15 | 45.00 |

--- a/exchange-rates/2025/09/17/central-money-exchange-20250917T195650103/request.json
+++ b/exchange-rates/2025/09/17/central-money-exchange-20250917T195650103/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-17T19:56:50.103012-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-17",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.204.227.39  0.257ms  0.257ms  0.135ms \n  2   140.204.28.36  10.137ms  9.957ms  10.141ms \n  3   140.204.28.37  11.350ms  *  10.555ms \n  4   141.101.72.83  9.494ms  8.969ms  9.450ms \n  5   104.21.95.5  10.402ms  10.456ms  10.451ms \n"
+}

--- a/exchange-rates/2025/09/17/central-money-exchange-20250917T195650103/response.json
+++ b/exchange-rates/2025/09/17/central-money-exchange-20250917T195650103/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 17 Sep 2025 23:08:48 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=OpZX2fmVp1Gdcs%2BkhfgMqbYcDYLbQNva1HDzMoQQLD6eKLLh0FnuvPWtyr7%2BldYDjtpZ5W2eKXK4QqfeUmZEzMBi0ZRD0EsDs2g%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "980c44806ee8f4ef-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7500,\"BuyEuroExchangeRate\":44.1500,\"SaleUsdExchangeRate\":38.1500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"17-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"08:08 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/17/central-money-exchange-20250917T195650103/results.json
+++ b/exchange-rates/2025/09/17/central-money-exchange-20250917T195650103/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.75",
+    "sell": "38.15",
+    "updated_on": "2025-09-17",
+    "updated_on_time": "08:08 PM"
+  },
+  "EUR": {
+    "buy": "44.15",
+    "sell": "45.00",
+    "updated_on": "2025-09-17",
+    "updated_on_time": "08:08 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/17/central-money-exchange-20250917T195650103) in the repository.