### PR TITLE
Central Money Exchange - September 18, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T012532757/README.md
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T012532757/README.md
@@ -1,0 +1,65 @@
+# Central Money Exchange Rates Snapshot 2025-09-18 01:25:32
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-18 |
+| Method | POST |
+| Timestamp | 2025-09-18T01:25:32.757929-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 18 Sep 2025 04:37:01 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Content-Encoding | gzip |
+| Cache-Control | private |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Report-To | {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=LKUB4EEQijiTfG4KzMluigx7%2B0tiucrq2PVcnlWabaqa9MGbhlso6L%2FrXCsk7tkEFRwvZ7FtKK1sLgyrpI2QLKo7dHRjTi1eGnjd58KpYhvtBjvR6Y57Nm9lZqFg"}],"group":"cf-nel","max_age":604800} |
+| NEL | {"success_fraction":0,"report_to":"cf-nel","max_age":604800} |
+| Server | cloudflare |
+| CF-RAY | 980e254b9ce26a9f-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+| server-timing | cfL4;desc="?proto=TCP&rtt=11264&min_rtt=11114&rtt_var=4275&sent=4&recv=6&lost=0&retrans=0&sent_bytes=2854&recv_bytes=1096&delivery_rate=260572&cwnd=251&unsent_bytes=0&cid=04d4f2818866ab85&ts=586&x=0" |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.227.57  0.308ms  0.198ms  0.142ms 
+  2   140.204.28.36  10.102ms  10.356ms  10.060ms 
+  3   *  *  140.204.28.37  11.008ms 
+  4   141.101.72.83  25.905ms  16.227ms  18.776ms 
+  5   172.67.142.118  9.024ms  9.025ms  9.059ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.75 | 38.15 |
+| EUR | 44.15 | 45.00 |

--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T012532757/request.json
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T012532757/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-18T01:25:32.757929-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-18",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.227.57  0.308ms  0.198ms  0.142ms \n  2   140.204.28.36  10.102ms  10.356ms  10.060ms \n  3   *  *  140.204.28.37  11.008ms \n  4   141.101.72.83  25.905ms  16.227ms  18.776ms \n  5   172.67.142.118  9.024ms  9.025ms  9.059ms \n"
+}

--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T012532757/response.json
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T012532757/response.json
@@ -1,0 +1,22 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 18 Sep 2025 04:37:01 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Content-Encoding": "gzip",
+    "Cache-Control": "private",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Report-To": "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=LKUB4EEQijiTfG4KzMluigx7%2B0tiucrq2PVcnlWabaqa9MGbhlso6L%2FrXCsk7tkEFRwvZ7FtKK1sLgyrpI2QLKo7dHRjTi1eGnjd58KpYhvtBjvR6Y57Nm9lZqFg\"}],\"group\":\"cf-nel\",\"max_age\":604800}",
+    "NEL": "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}",
+    "Server": "cloudflare",
+    "CF-RAY": "980e254b9ce26a9f-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400",
+    "server-timing": "cfL4;desc=\"?proto=TCP&rtt=11264&min_rtt=11114&rtt_var=4275&sent=4&recv=6&lost=0&retrans=0&sent_bytes=2854&recv_bytes=1096&delivery_rate=260572&cwnd=251&unsent_bytes=0&cid=04d4f2818866ab85&ts=586&x=0\""
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7500,\"BuyEuroExchangeRate\":44.1500,\"SaleUsdExchangeRate\":38.1500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"18-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"01:37 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T012532757/results.json
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T012532757/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.75",
+    "sell": "38.15",
+    "updated_on": "2025-09-18",
+    "updated_on_time": "01:37 AM"
+  },
+  "EUR": {
+    "buy": "44.15",
+    "sell": "45.00",
+    "updated_on": "2025-09-18",
+    "updated_on_time": "01:37 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/18/central-money-exchange-20250918T012532757) in the repository.