### PR TITLE
Central Money Exchange - September 18, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T081512887/README.md
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T081512887/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-18 08:15:12
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-18 |
+| Method | POST |
+| Timestamp | 2025-09-18T08:15:12.887748-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 18 Sep 2025 11:26:11 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=3ohCUSSK9aRDbtrcAtdhTATZyOg3zkh%2BAGXEV27%2FFv9PMVxs3viuIVN3GXDEjvYO1sCqBAptwcR3UpcbZzCf7iS6Y%2F1GCBWNe8Q%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98107ca7995a0fbe-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.91.194.61  0.216ms  0.123ms  0.199ms 
+  2   140.204.28.36  9.898ms  9.991ms  35.605ms 
+  3   140.204.28.37  9.015ms  9.070ms  9.038ms 
+  4   141.101.72.83  12.461ms  12.519ms  12.495ms 
+  5   172.67.142.118  11.974ms  11.926ms  11.928ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.55 | 38.05 |
+| EUR | 44.35 | 45.00 |

--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T081512887/request.json
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T081512887/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-18T08:15:12.887748-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-18",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.91.194.61  0.216ms  0.123ms  0.199ms \n  2   140.204.28.36  9.898ms  9.991ms  35.605ms \n  3   140.204.28.37  9.015ms  9.070ms  9.038ms \n  4   141.101.72.83  12.461ms  12.519ms  12.495ms \n  5   172.67.142.118  11.974ms  11.926ms  11.928ms \n"
+}

--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T081512887/response.json
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T081512887/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 18 Sep 2025 11:26:11 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=3ohCUSSK9aRDbtrcAtdhTATZyOg3zkh%2BAGXEV27%2FFv9PMVxs3viuIVN3GXDEjvYO1sCqBAptwcR3UpcbZzCf7iS6Y%2F1GCBWNe8Q%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98107ca7995a0fbe-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5500,\"BuyEuroExchangeRate\":44.3500,\"SaleUsdExchangeRate\":38.0500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"18-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"08:26 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T081512887/results.json
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T081512887/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.55",
+    "sell": "38.05",
+    "updated_on": "2025-09-18",
+    "updated_on_time": "08:26 AM"
+  },
+  "EUR": {
+    "buy": "44.35",
+    "sell": "45.00",
+    "updated_on": "2025-09-18",
+    "updated_on_time": "08:26 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/18/central-money-exchange-20250918T081512887) in the repository.