### PR TITLE
Central Money Exchange - September 18, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T134144957/README.md
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T134144957/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-18 13:41:44
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-18 |
+| Method | POST |
+| Timestamp | 2025-09-18T13:41:44.957129-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 18 Sep 2025 16:53:11 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=N2Aw0rgADfOFlkEeQ9XZtmpAdorDSe6Hbpm7qSzSZ%2Fqlxl2TreWzc6KojcU37%2FGll2YGEvbDC%2F9tRjqT%2Fi4C%2FNLgzWzfUhXrQ3o%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98125baa4ec77bbb-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.204.227.35  0.385ms  0.132ms  0.112ms 
+  2   140.204.28.36  10.065ms  10.045ms  10.224ms 
+  3   *  *  140.204.28.37  13.248ms 
+  4   141.101.72.83  11.355ms  10.824ms  10.320ms 
+  5   104.21.95.5  9.076ms  8.962ms  8.744ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.55 | 38.05 |
+| EUR | 44.35 | 45.00 |

--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T134144957/request.json
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T134144957/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-18T13:41:44.957129-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-18",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.204.227.35  0.385ms  0.132ms  0.112ms \n  2   140.204.28.36  10.065ms  10.045ms  10.224ms \n  3   *  *  140.204.28.37  13.248ms \n  4   141.101.72.83  11.355ms  10.824ms  10.320ms \n  5   104.21.95.5  9.076ms  8.962ms  8.744ms \n"
+}

--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T134144957/response.json
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T134144957/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 18 Sep 2025 16:53:11 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=N2Aw0rgADfOFlkEeQ9XZtmpAdorDSe6Hbpm7qSzSZ%2Fqlxl2TreWzc6KojcU37%2FGll2YGEvbDC%2F9tRjqT%2Fi4C%2FNLgzWzfUhXrQ3o%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98125baa4ec77bbb-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5500,\"BuyEuroExchangeRate\":44.3500,\"SaleUsdExchangeRate\":38.0500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"18-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"01:53 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/18/central-money-exchange-20250918T134144957/results.json
+++ b/exchange-rates/2025/09/18/central-money-exchange-20250918T134144957/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.55",
+    "sell": "38.05",
+    "updated_on": "2025-09-18",
+    "updated_on_time": "01:53 PM"
+  },
+  "EUR": {
+    "buy": "44.35",
+    "sell": "45.00",
+    "updated_on": "2025-09-18",
+    "updated_on_time": "01:53 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/18/central-money-exchange-20250918T134144957) in the repository.