### PR TITLE
Central Money Exchange - September 24, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T043642584/README.md
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T043642584/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-24 04:36:42
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-24 |
+| Method | POST |
+| Timestamp | 2025-09-24T04:36:42.584698-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 24 Sep 2025 07:47:51 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=AlHq9M09wyil67mQtYQuNj16ImUNHHPypbg75YCPRJafqtEa6e%2B9Mh7Dc0i3H6K5pxhhTzc9gYqxJyCTlDzJAXb%2FHbmBTwm5XHs%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 9840ad10ffa4cbaf-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.226.219  0.173ms  0.168ms  0.133ms 
+  2   140.204.28.36  11.873ms  11.560ms  11.473ms 
+  3   *  140.204.28.37  27.307ms  * 
+  4   141.101.72.34  12.732ms  11.974ms  11.947ms 
+  5   172.67.142.118  8.902ms  8.924ms  8.958ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.55 | 38.05 |
+| EUR | 44.35 | 45.00 |

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T043642584/request.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T043642584/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-24T04:36:42.584698-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-24",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.226.219  0.173ms  0.168ms  0.133ms \n  2   140.204.28.36  11.873ms  11.560ms  11.473ms \n  3   *  140.204.28.37  27.307ms  * \n  4   141.101.72.34  12.732ms  11.974ms  11.947ms \n  5   172.67.142.118  8.902ms  8.924ms  8.958ms \n"
+}

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T043642584/response.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T043642584/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 24 Sep 2025 07:47:51 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=AlHq9M09wyil67mQtYQuNj16ImUNHHPypbg75YCPRJafqtEa6e%2B9Mh7Dc0i3H6K5pxhhTzc9gYqxJyCTlDzJAXb%2FHbmBTwm5XHs%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "9840ad10ffa4cbaf-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5500,\"BuyEuroExchangeRate\":44.3500,\"SaleUsdExchangeRate\":38.0500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"24-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"04:47 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T043642584/results.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T043642584/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.55",
+    "sell": "38.05",
+    "updated_on": "2025-09-24",
+    "updated_on_time": "04:47 AM"
+  },
+  "EUR": {
+    "buy": "44.35",
+    "sell": "45.00",
+    "updated_on": "2025-09-24",
+    "updated_on_time": "04:47 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/24/central-money-exchange-20250924T043642584) in the repository.