### PR TITLE
Central Money Exchange - September 24, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T112451849/README.md
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T112451849/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-24 11:24:51
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-24 |
+| Method | POST |
+| Timestamp | 2025-09-24T11:24:51.849707-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 24 Sep 2025 14:35:54 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=EAPbybS%2FAFnMN20uaPrwPd97SNMkARpOejs7IB6zFHux97McNramBuN7yxTaXPMUal%2Fs%2BYa8N4TfzTDxYZn%2BYPXKZ0nGmHxEUaA%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 984302cdcfab090d-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.226.237  0.345ms  0.179ms  0.146ms 
+  2   140.204.28.36  8.449ms  8.375ms  8.758ms 
+  3   140.204.28.37  15.970ms  *  * 
+  4   141.101.72.31  11.547ms  11.148ms  10.553ms 
+  5   172.67.142.118  12.200ms  12.144ms  12.127ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.55 | 38.05 |
+| EUR | 44.25 | 45.00 |

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T112451849/request.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T112451849/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-24T11:24:51.849707-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-24",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.226.237  0.345ms  0.179ms  0.146ms \n  2   140.204.28.36  8.449ms  8.375ms  8.758ms \n  3   140.204.28.37  15.970ms  *  * \n  4   141.101.72.31  11.547ms  11.148ms  10.553ms \n  5   172.67.142.118  12.200ms  12.144ms  12.127ms \n"
+}

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T112451849/response.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T112451849/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 24 Sep 2025 14:35:54 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=EAPbybS%2FAFnMN20uaPrwPd97SNMkARpOejs7IB6zFHux97McNramBuN7yxTaXPMUal%2Fs%2BYa8N4TfzTDxYZn%2BYPXKZ0nGmHxEUaA%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "984302cdcfab090d-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5500,\"BuyEuroExchangeRate\":44.2500,\"SaleUsdExchangeRate\":38.0500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"24-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"11:35 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T112451849/results.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T112451849/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.55",
+    "sell": "38.05",
+    "updated_on": "2025-09-24",
+    "updated_on_time": "11:35 AM"
+  },
+  "EUR": {
+    "buy": "44.25",
+    "sell": "45.00",
+    "updated_on": "2025-09-24",
+    "updated_on_time": "11:35 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/24/central-money-exchange-20250924T112451849) in the repository.