### PR TITLE
Central Money Exchange - September 24, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T181327792/README.md
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T181327792/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-24 18:13:27
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-24 |
+| Method | POST |
+| Timestamp | 2025-09-24T18:13:27.792666-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 24 Sep 2025 21:24:53 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=73CZCm0J9FPZFF13OkC5WYVlgmdCVfDq51wlyyHNpJ2BIlXuXgLXFiV9hcNEdA9tf3XpvVTSjE6t%2B%2FZUHF6jS81JE744Q2ZrM%2BI%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 984559e6da621011-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.227.71  0.238ms  0.177ms  0.185ms 
+  2   140.204.28.36  11.739ms  11.534ms  11.749ms 
+  3   140.204.28.37  12.472ms  11.977ms  * 
+  4   141.101.72.34  12.390ms  12.503ms  12.141ms 
+  5   172.67.142.118  10.864ms  10.616ms  10.624ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.55 | 38.05 |
+| EUR | 44.25 | 45.00 |

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T181327792/request.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T181327792/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-24T18:13:27.792666-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-24",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.227.71  0.238ms  0.177ms  0.185ms \n  2   140.204.28.36  11.739ms  11.534ms  11.749ms \n  3   140.204.28.37  12.472ms  11.977ms  * \n  4   141.101.72.34  12.390ms  12.503ms  12.141ms \n  5   172.67.142.118  10.864ms  10.616ms  10.624ms \n"
+}

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T181327792/response.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T181327792/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 24 Sep 2025 21:24:53 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=73CZCm0J9FPZFF13OkC5WYVlgmdCVfDq51wlyyHNpJ2BIlXuXgLXFiV9hcNEdA9tf3XpvVTSjE6t%2B%2FZUHF6jS81JE744Q2ZrM%2BI%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "984559e6da621011-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5500,\"BuyEuroExchangeRate\":44.2500,\"SaleUsdExchangeRate\":38.0500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"24-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"06:24 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T181327792/results.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T181327792/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.55",
+    "sell": "38.05",
+    "updated_on": "2025-09-24",
+    "updated_on_time": "06:24 PM"
+  },
+  "EUR": {
+    "buy": "44.25",
+    "sell": "45.00",
+    "updated_on": "2025-09-24",
+    "updated_on_time": "06:24 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/24/central-money-exchange-20250924T181327792) in the repository.