### PR TITLE
Central Money Exchange - September 24, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T221929365/README.md
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T221929365/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-24 22:19:29
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-24 |
+| Method | POST |
+| Timestamp | 2025-09-24T22:19:29.365745-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 25 Sep 2025 01:30:38 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=75BnqERs%2BHxseCM1axhy0yr1kfYB9SZeSWnOjJhEefxBmCutp7pjYwoli69mzxgsC0IjsQchzLeLoFD7vR52KZxPhYvxHsU8Ab0%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 9846c1d0e89bc277-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.227.63  0.370ms  0.190ms  0.258ms 
+  2   140.204.28.36  11.496ms  11.498ms  11.482ms 
+  3   *  *  * 
+  4   141.101.72.83  13.073ms  12.246ms  12.844ms 
+  5   172.67.142.118  10.580ms  10.584ms  10.609ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.55 | 38.05 |
+| EUR | 44.25 | 45.00 |

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T221929365/request.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T221929365/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-24T22:19:29.365745-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-24",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.227.63  0.370ms  0.190ms  0.258ms \n  2   140.204.28.36  11.496ms  11.498ms  11.482ms \n  3   *  *  * \n  4   141.101.72.83  13.073ms  12.246ms  12.844ms \n  5   172.67.142.118  10.580ms  10.584ms  10.609ms \n"
+}

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T221929365/response.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T221929365/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 25 Sep 2025 01:30:38 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=75BnqERs%2BHxseCM1axhy0yr1kfYB9SZeSWnOjJhEefxBmCutp7pjYwoli69mzxgsC0IjsQchzLeLoFD7vR52KZxPhYvxHsU8Ab0%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "9846c1d0e89bc277-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5500,\"BuyEuroExchangeRate\":44.2500,\"SaleUsdExchangeRate\":38.0500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"24-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"10:30 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/24/central-money-exchange-20250924T221929365/results.json
+++ b/exchange-rates/2025/09/24/central-money-exchange-20250924T221929365/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.55",
+    "sell": "38.05",
+    "updated_on": "2025-09-24",
+    "updated_on_time": "10:30 PM"
+  },
+  "EUR": {
+    "buy": "44.25",
+    "sell": "45.00",
+    "updated_on": "2025-09-24",
+    "updated_on_time": "10:30 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/24/central-money-exchange-20250924T221929365) in the repository.