### PR TITLE
Central Money Exchange - September 25, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/25/central-money-exchange-20250925T010220404/README.md
+++ b/exchange-rates/2025/09/25/central-money-exchange-20250925T010220404/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-25 01:02:20
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-25 |
+| Method | POST |
+| Timestamp | 2025-09-25T01:02:20.404458-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 25 Sep 2025 04:13:47 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=bNDdQQw8xNysME8vGuqopEVxXPPOoDgcVJ1L3bAz7MYpM%2Bn4%2BIvfk%2Bjsk2RFkfJG%2B6iLkp0foq0iDmmkaIPyI1s4gcMVilyjZtg%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 9847b0e0ef2b341c-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.91.194.63  0.150ms  0.069ms  0.107ms 
+  2   140.204.28.36  9.987ms  9.900ms  10.322ms 
+  3   140.204.28.37  10.916ms  10.852ms  10.733ms 
+  4   141.101.72.27  11.063ms  18.851ms  11.030ms 
+  5   104.21.95.5  8.785ms  8.751ms  8.739ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.55 | 38.05 |
+| EUR | 44.25 | 45.00 |

--- a/exchange-rates/2025/09/25/central-money-exchange-20250925T010220404/request.json
+++ b/exchange-rates/2025/09/25/central-money-exchange-20250925T010220404/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-25T01:02:20.404458-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-25",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.91.194.63  0.150ms  0.069ms  0.107ms \n  2   140.204.28.36  9.987ms  9.900ms  10.322ms \n  3   140.204.28.37  10.916ms  10.852ms  10.733ms \n  4   141.101.72.27  11.063ms  18.851ms  11.030ms \n  5   104.21.95.5  8.785ms  8.751ms  8.739ms \n"
+}

--- a/exchange-rates/2025/09/25/central-money-exchange-20250925T010220404/response.json
+++ b/exchange-rates/2025/09/25/central-money-exchange-20250925T010220404/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 25 Sep 2025 04:13:47 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=bNDdQQw8xNysME8vGuqopEVxXPPOoDgcVJ1L3bAz7MYpM%2Bn4%2BIvfk%2Bjsk2RFkfJG%2B6iLkp0foq0iDmmkaIPyI1s4gcMVilyjZtg%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "9847b0e0ef2b341c-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.5500,\"BuyEuroExchangeRate\":44.2500,\"SaleUsdExchangeRate\":38.0500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1500,\"ExchangeUsdRateNew\":1.1500,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"25-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"01:13 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/25/central-money-exchange-20250925T010220404/results.json
+++ b/exchange-rates/2025/09/25/central-money-exchange-20250925T010220404/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.55",
+    "sell": "38.05",
+    "updated_on": "2025-09-25",
+    "updated_on_time": "01:13 AM"
+  },
+  "EUR": {
+    "buy": "44.25",
+    "sell": "45.00",
+    "updated_on": "2025-09-25",
+    "updated_on_time": "01:13 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/25/central-money-exchange-20250925T010220404) in the repository.