### PR TITLE
Central Money Exchange - September 25, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/25/central-money-exchange-20250925T201107776/README.md
+++ b/exchange-rates/2025/09/25/central-money-exchange-20250925T201107776/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-25 20:11:07
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-25 |
+| Method | POST |
+| Timestamp | 2025-09-25T20:11:07.776145-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 25 Sep 2025 23:23:06 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=JNChG71ArzjeHlZBYj4dAyt5WFvPyprTF6nay6T5RWCttETJKuFl6HD9aY3MtgMjXgNlOJWrqWSai40af%2FKNppmafDj11fVi8YM%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 984e446f7a123233-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.204.227.63  0.312ms  0.179ms  0.144ms 
+  2   140.204.28.36  10.028ms  10.048ms  10.131ms 
+  3   140.204.28.37  10.791ms  13.299ms  11.187ms 
+  4   141.101.72.34  11.444ms  11.130ms  11.323ms 
+  5   104.21.95.5  8.909ms  8.847ms  8.767ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 44.00 | 45.00 |

--- a/exchange-rates/2025/09/25/central-money-exchange-20250925T201107776/request.json
+++ b/exchange-rates/2025/09/25/central-money-exchange-20250925T201107776/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-25T20:11:07.776145-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-25",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.204.227.63  0.312ms  0.179ms  0.144ms \n  2   140.204.28.36  10.028ms  10.048ms  10.131ms \n  3   140.204.28.37  10.791ms  13.299ms  11.187ms \n  4   141.101.72.34  11.444ms  11.130ms  11.323ms \n  5   104.21.95.5  8.909ms  8.847ms  8.767ms \n"
+}

--- a/exchange-rates/2025/09/25/central-money-exchange-20250925T201107776/response.json
+++ b/exchange-rates/2025/09/25/central-money-exchange-20250925T201107776/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 25 Sep 2025 23:23:06 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=JNChG71ArzjeHlZBYj4dAyt5WFvPyprTF6nay6T5RWCttETJKuFl6HD9aY3MtgMjXgNlOJWrqWSai40af%2FKNppmafDj11fVi8YM%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "984e446f7a123233-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":44.0000,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"25-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"08:23 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/25/central-money-exchange-20250925T201107776/results.json
+++ b/exchange-rates/2025/09/25/central-money-exchange-20250925T201107776/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-25",
+    "updated_on_time": "08:23 PM"
+  },
+  "EUR": {
+    "buy": "44.00",
+    "sell": "45.00",
+    "updated_on": "2025-09-25",
+    "updated_on_time": "08:23 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/25/central-money-exchange-20250925T201107776) in the repository.