### PR TITLE
Central Money Exchange - September 26, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/26/central-money-exchange-20250926T013759862/README.md
+++ b/exchange-rates/2025/09/26/central-money-exchange-20250926T013759862/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-26 01:37:59
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-26 |
+| Method | POST |
+| Timestamp | 2025-09-26T01:37:59.862623-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Fri, 26 Sep 2025 04:49:39 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=xMTIir2Wc42gpofNhsOAbg98zailJNg6RVGrqQ2DdVys7%2BmspnQAlVAKsV4hG5DyDFy9t%2BE1l%2BuYhvj3w3rwfWndaW6pLi4MdbQ%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 985022c7eb242668-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.204.226.229  0.257ms  0.170ms  0.146ms 
+  2   140.204.28.36  10.146ms  10.171ms  9.900ms 
+  3   140.204.28.37  44.964ms  44.920ms  62.032ms 
+  4   141.101.72.87  44.742ms  45.518ms  44.074ms 
+  5   104.21.95.5  58.783ms  56.381ms  54.803ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 44.00 | 45.00 |

--- a/exchange-rates/2025/09/26/central-money-exchange-20250926T013759862/request.json
+++ b/exchange-rates/2025/09/26/central-money-exchange-20250926T013759862/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-26T01:37:59.862623-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-26",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.204.226.229  0.257ms  0.170ms  0.146ms \n  2   140.204.28.36  10.146ms  10.171ms  9.900ms \n  3   140.204.28.37  44.964ms  44.920ms  62.032ms \n  4   141.101.72.87  44.742ms  45.518ms  44.074ms \n  5   104.21.95.5  58.783ms  56.381ms  54.803ms \n"
+}

--- a/exchange-rates/2025/09/26/central-money-exchange-20250926T013759862/response.json
+++ b/exchange-rates/2025/09/26/central-money-exchange-20250926T013759862/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Fri, 26 Sep 2025 04:49:39 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=xMTIir2Wc42gpofNhsOAbg98zailJNg6RVGrqQ2DdVys7%2BmspnQAlVAKsV4hG5DyDFy9t%2BE1l%2BuYhvj3w3rwfWndaW6pLi4MdbQ%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "985022c7eb242668-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":44.0000,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":45.0000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"26-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"01:49 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/26/central-money-exchange-20250926T013759862/results.json
+++ b/exchange-rates/2025/09/26/central-money-exchange-20250926T013759862/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-26",
+    "updated_on_time": "01:49 AM"
+  },
+  "EUR": {
+    "buy": "44.00",
+    "sell": "45.00",
+    "updated_on": "2025-09-26",
+    "updated_on_time": "01:49 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/26/central-money-exchange-20250926T013759862) in the repository.