### PR TITLE
Central Money Exchange - September 26, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/26/central-money-exchange-20250926T094832959/README.md
+++ b/exchange-rates/2025/09/26/central-money-exchange-20250926T094832959/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-26 09:48:32
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-26 |
+| Method | POST |
+| Timestamp | 2025-09-26T09:48:32.959288-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Fri, 26 Sep 2025 12:59:33 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=KNP0AemCQ308ECLDrkhWKDR%2F52hGYs332jR2FNJZVlxUYNSha2uLpF%2Fcdd20tZicXPQlrVels18hd9XVGfXlQ6w6aDK6TEL5nHg%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 9852f06a1eed4e43-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.91.194.19  0.272ms  0.137ms  0.138ms 
+  2   140.204.28.36  9.967ms  9.832ms  9.942ms 
+  3   140.204.28.37  9.186ms  9.228ms  9.229ms 
+  4   141.101.72.27  12.273ms  12.818ms  12.856ms 
+  5   *  172.67.142.118  10.551ms  10.443ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 43.75 | 44.90 |

--- a/exchange-rates/2025/09/26/central-money-exchange-20250926T094832959/request.json
+++ b/exchange-rates/2025/09/26/central-money-exchange-20250926T094832959/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-26T09:48:32.959288-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-26",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.91.194.19  0.272ms  0.137ms  0.138ms \n  2   140.204.28.36  9.967ms  9.832ms  9.942ms \n  3   140.204.28.37  9.186ms  9.228ms  9.229ms \n  4   141.101.72.27  12.273ms  12.818ms  12.856ms \n  5   *  172.67.142.118  10.551ms  10.443ms \n"
+}

--- a/exchange-rates/2025/09/26/central-money-exchange-20250926T094832959/response.json
+++ b/exchange-rates/2025/09/26/central-money-exchange-20250926T094832959/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Fri, 26 Sep 2025 12:59:33 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=KNP0AemCQ308ECLDrkhWKDR%2F52hGYs332jR2FNJZVlxUYNSha2uLpF%2Fcdd20tZicXPQlrVels18hd9XVGfXlQ6w6aDK6TEL5nHg%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "9852f06a1eed4e43-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":44.9000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"26-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"09:59 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/26/central-money-exchange-20250926T094832959/results.json
+++ b/exchange-rates/2025/09/26/central-money-exchange-20250926T094832959/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-26",
+    "updated_on_time": "09:59 AM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.90",
+    "updated_on": "2025-09-26",
+    "updated_on_time": "09:59 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/26/central-money-exchange-20250926T094832959) in the repository.