### PR TITLE
Central Money Exchange - September 27, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/27/central-money-exchange-20250927T181935376/README.md
+++ b/exchange-rates/2025/09/27/central-money-exchange-20250927T181935376/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-27 18:19:35
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-27 |
+| Method | POST |
+| Timestamp | 2025-09-27T18:19:35.376099-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sat, 27 Sep 2025 21:31:01 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=6mTnqwfZo3oFNccHe644%2FU5sQBlkvP5OlQjPvst3O37TJ8ejiDBYyYFK%2BHt%2FB%2FBZVDCpRP5jZ6er6qUzYDS6Fp01ajOzpllWilc%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 985e1b01acd67c41-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.227.41  0.414ms  0.163ms  0.155ms 
+  2   140.204.28.36  8.557ms  8.371ms  8.314ms 
+  3   140.204.28.37  11.116ms  10.799ms  10.934ms 
+  4   141.101.72.21  18.962ms  17.982ms  20.914ms 
+  5   172.67.142.118  8.921ms  8.806ms  8.802ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 43.75 | 44.90 |

--- a/exchange-rates/2025/09/27/central-money-exchange-20250927T181935376/request.json
+++ b/exchange-rates/2025/09/27/central-money-exchange-20250927T181935376/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-27T18:19:35.376099-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-27",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.227.41  0.414ms  0.163ms  0.155ms \n  2   140.204.28.36  8.557ms  8.371ms  8.314ms \n  3   140.204.28.37  11.116ms  10.799ms  10.934ms \n  4   141.101.72.21  18.962ms  17.982ms  20.914ms \n  5   172.67.142.118  8.921ms  8.806ms  8.802ms \n"
+}

--- a/exchange-rates/2025/09/27/central-money-exchange-20250927T181935376/response.json
+++ b/exchange-rates/2025/09/27/central-money-exchange-20250927T181935376/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sat, 27 Sep 2025 21:31:01 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=6mTnqwfZo3oFNccHe644%2FU5sQBlkvP5OlQjPvst3O37TJ8ejiDBYyYFK%2BHt%2FB%2FBZVDCpRP5jZ6er6qUzYDS6Fp01ajOzpllWilc%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "985e1b01acd67c41-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":44.9000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"27-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"06:31 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/27/central-money-exchange-20250927T181935376/results.json
+++ b/exchange-rates/2025/09/27/central-money-exchange-20250927T181935376/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-27",
+    "updated_on_time": "06:31 PM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.90",
+    "updated_on": "2025-09-27",
+    "updated_on_time": "06:31 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/27/central-money-exchange-20250927T181935376) in the repository.