### PR TITLE
Central Money Exchange - September 28, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/28/central-money-exchange-20250928T115951242/README.md
+++ b/exchange-rates/2025/09/28/central-money-exchange-20250928T115951242/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-28 11:59:51
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-28 |
+| Method | POST |
+| Timestamp | 2025-09-28T11:59:51.242881-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sun, 28 Sep 2025 15:11:16 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=E9%2FK9nbrZoPxU38OdJsNU866kRWucxCJubLokxHZQF%2B%2BrHKkSQKkrAm4Y61%2FFERUM4wRoaMgotIdyhw03I3eewE2%2BXRM3vwNx2c%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98642c1e4ce12f53-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.204.227.45  0.189ms  0.091ms  0.368ms 
+  2   140.204.28.36  9.865ms  9.818ms  9.735ms 
+  3   *  140.204.28.37  10.783ms  10.653ms 
+  4   141.101.72.83  10.996ms  20.653ms  15.271ms 
+  5   104.21.95.5  12.049ms  12.026ms  11.957ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 43.75 | 44.90 |

--- a/exchange-rates/2025/09/28/central-money-exchange-20250928T115951242/request.json
+++ b/exchange-rates/2025/09/28/central-money-exchange-20250928T115951242/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-28T11:59:51.242881-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-28",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.204.227.45  0.189ms  0.091ms  0.368ms \n  2   140.204.28.36  9.865ms  9.818ms  9.735ms \n  3   *  140.204.28.37  10.783ms  10.653ms \n  4   141.101.72.83  10.996ms  20.653ms  15.271ms \n  5   104.21.95.5  12.049ms  12.026ms  11.957ms \n"
+}

--- a/exchange-rates/2025/09/28/central-money-exchange-20250928T115951242/response.json
+++ b/exchange-rates/2025/09/28/central-money-exchange-20250928T115951242/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sun, 28 Sep 2025 15:11:16 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=E9%2FK9nbrZoPxU38OdJsNU866kRWucxCJubLokxHZQF%2B%2BrHKkSQKkrAm4Y61%2FFERUM4wRoaMgotIdyhw03I3eewE2%2BXRM3vwNx2c%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98642c1e4ce12f53-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":44.9000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"28-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"12:11 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/28/central-money-exchange-20250928T115951242/results.json
+++ b/exchange-rates/2025/09/28/central-money-exchange-20250928T115951242/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-28",
+    "updated_on_time": "12:11 PM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.90",
+    "updated_on": "2025-09-28",
+    "updated_on_time": "12:11 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/28/central-money-exchange-20250928T115951242) in the repository.