### PR TITLE
Central Money Exchange - September 28, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/28/central-money-exchange-20250928T184854687/README.md
+++ b/exchange-rates/2025/09/28/central-money-exchange-20250928T184854687/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-28 18:48:54
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-28 |
+| Method | POST |
+| Timestamp | 2025-09-28T18:48:54.687011-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sun, 28 Sep 2025 21:59:52 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=KccCS6CxzDu5r2RC4DWrovt9diswotXg1D%2B9hQcwzpUjFVksSSIrR%2BEf84dE3G7EqvC9JcbDSWZdBsm1xOpOu4CgpMQXiUASncc%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 986682a6cf012ef0-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.227.21  0.214ms  0.076ms  0.117ms 
+  2   140.204.28.36  11.705ms  11.498ms  11.368ms 
+  3   140.204.28.37  32.952ms  33.046ms  33.039ms 
+  4   141.101.72.31  33.984ms  34.458ms  34.408ms 
+  5   172.67.142.118  34.982ms  35.325ms  34.135ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 43.75 | 44.90 |

--- a/exchange-rates/2025/09/28/central-money-exchange-20250928T184854687/request.json
+++ b/exchange-rates/2025/09/28/central-money-exchange-20250928T184854687/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-28T18:48:54.687011-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-28",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.227.21  0.214ms  0.076ms  0.117ms \n  2   140.204.28.36  11.705ms  11.498ms  11.368ms \n  3   140.204.28.37  32.952ms  33.046ms  33.039ms \n  4   141.101.72.31  33.984ms  34.458ms  34.408ms \n  5   172.67.142.118  34.982ms  35.325ms  34.135ms \n"
+}

--- a/exchange-rates/2025/09/28/central-money-exchange-20250928T184854687/response.json
+++ b/exchange-rates/2025/09/28/central-money-exchange-20250928T184854687/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sun, 28 Sep 2025 21:59:52 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=KccCS6CxzDu5r2RC4DWrovt9diswotXg1D%2B9hQcwzpUjFVksSSIrR%2BEf84dE3G7EqvC9JcbDSWZdBsm1xOpOu4CgpMQXiUASncc%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "986682a6cf012ef0-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":44.9000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"28-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"06:59 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/28/central-money-exchange-20250928T184854687/results.json
+++ b/exchange-rates/2025/09/28/central-money-exchange-20250928T184854687/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-28",
+    "updated_on_time": "06:59 PM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.90",
+    "updated_on": "2025-09-28",
+    "updated_on_time": "06:59 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/28/central-money-exchange-20250928T184854687) in the repository.