### PR TITLE
Central Money Exchange - September 29, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T041726186/README.md
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T041726186/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-29 04:17:26
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-29 |
+| Method | POST |
+| Timestamp | 2025-09-29T04:17:26.186882-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Mon, 29 Sep 2025 07:28:52 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=gDYLXW4IiYqBrOfaNdUkmnsV7iXptrSFAfTXnZtdqxCuAejnB3hfB34GbWZPBSyqV2P9TbWCr3xsiTjfhFCxqr8H3lOZ7690sIs%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 9869c4224d261008-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.91.194.60  0.145ms  0.121ms  0.102ms 
+  2   140.204.28.36  8.376ms  8.385ms  8.430ms 
+  3   140.204.28.37  12.323ms  *  12.204ms 
+  4   141.101.72.34  16.836ms  15.386ms  20.080ms 
+  5   104.21.95.5  10.479ms  10.428ms  10.425ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 43.75 | 44.90 |

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T041726186/request.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T041726186/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-29T04:17:26.186882-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-29",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.91.194.60  0.145ms  0.121ms  0.102ms \n  2   140.204.28.36  8.376ms  8.385ms  8.430ms \n  3   140.204.28.37  12.323ms  *  12.204ms \n  4   141.101.72.34  16.836ms  15.386ms  20.080ms \n  5   104.21.95.5  10.479ms  10.428ms  10.425ms \n"
+}

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T041726186/response.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T041726186/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Mon, 29 Sep 2025 07:28:52 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=gDYLXW4IiYqBrOfaNdUkmnsV7iXptrSFAfTXnZtdqxCuAejnB3hfB34GbWZPBSyqV2P9TbWCr3xsiTjfhFCxqr8H3lOZ7690sIs%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "9869c4224d261008-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":44.9000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"29-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"04:28 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T041726186/results.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T041726186/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-29",
+    "updated_on_time": "04:28 AM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.90",
+    "updated_on": "2025-09-29",
+    "updated_on_time": "04:28 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/29/central-money-exchange-20250929T041726186) in the repository.