### PR TITLE
Central Money Exchange - September 29, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T053828848/README.md
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T053828848/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-29 05:38:28
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-29 |
+| Method | POST |
+| Timestamp | 2025-09-29T05:38:28.848517-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Mon, 29 Sep 2025 08:49:55 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=hezp%2ForUFZ1XHc0im7%2By7ESf7eOCNb20pSx4StCEXuDJPApStNSxsMqKb%2FOtTjrlfC7junb8hZ12AVAvm7aMGs8GTLZ%2Bb19ziIU%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 986a3adf7e8bcb91-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.226.227  0.210ms  0.107ms  0.101ms 
+  2   140.204.28.36  11.577ms  11.670ms  11.561ms 
+  3   140.204.28.37  9.345ms  8.968ms  8.948ms 
+  4   141.101.72.27  11.023ms  11.448ms  11.060ms 
+  5   172.67.142.118  8.966ms  8.859ms  9.006ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 43.75 | 44.90 |

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T053828848/request.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T053828848/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-29T05:38:28.848517-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-29",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.226.227  0.210ms  0.107ms  0.101ms \n  2   140.204.28.36  11.577ms  11.670ms  11.561ms \n  3   140.204.28.37  9.345ms  8.968ms  8.948ms \n  4   141.101.72.27  11.023ms  11.448ms  11.060ms \n  5   172.67.142.118  8.966ms  8.859ms  9.006ms \n"
+}

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T053828848/response.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T053828848/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Mon, 29 Sep 2025 08:49:55 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=hezp%2ForUFZ1XHc0im7%2By7ESf7eOCNb20pSx4StCEXuDJPApStNSxsMqKb%2FOtTjrlfC7junb8hZ12AVAvm7aMGs8GTLZ%2Bb19ziIU%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "986a3adf7e8bcb91-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":44.9000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"29-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"05:49 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T053828848/results.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T053828848/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-29",
+    "updated_on_time": "05:49 AM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.90",
+    "updated_on": "2025-09-29",
+    "updated_on_time": "05:49 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/29/central-money-exchange-20250929T053828848) in the repository.