### PR TITLE
Central Money Exchange - September 29, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T191624060/README.md
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T191624060/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-29 19:16:24
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-29 |
+| Method | POST |
+| Timestamp | 2025-09-29T19:16:24.060454-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Mon, 29 Sep 2025 22:27:22 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=BpwqwptKyRk%2FN4EaDVJX%2BfOS351WsZalGABX0NXP7pKjfp0yyFtNeqSsXULfDetKMHYhfGWFUSjbLEJVnqN7ECpU9vbLPezVKuI%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 986ee84d49ad08b2-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.91.194.103  0.390ms  0.169ms  0.136ms 
+  2   140.204.28.36  8.495ms  8.364ms  8.666ms 
+  3   *  *  140.204.28.37  12.268ms 
+  4   141.101.72.34  11.096ms  11.214ms  11.109ms 
+  5   172.67.142.118  10.831ms  10.616ms  10.624ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 43.90 | 44.90 |

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T191624060/request.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T191624060/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-29T19:16:24.060454-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-29",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.91.194.103  0.390ms  0.169ms  0.136ms \n  2   140.204.28.36  8.495ms  8.364ms  8.666ms \n  3   *  *  140.204.28.37  12.268ms \n  4   141.101.72.34  11.096ms  11.214ms  11.109ms \n  5   172.67.142.118  10.831ms  10.616ms  10.624ms \n"
+}

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T191624060/response.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T191624060/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Mon, 29 Sep 2025 22:27:22 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=BpwqwptKyRk%2FN4EaDVJX%2BfOS351WsZalGABX0NXP7pKjfp0yyFtNeqSsXULfDetKMHYhfGWFUSjbLEJVnqN7ECpU9vbLPezVKuI%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "986ee84d49ad08b2-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.9000,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":44.9000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"29-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"07:27 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T191624060/results.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T191624060/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-29",
+    "updated_on_time": "07:27 PM"
+  },
+  "EUR": {
+    "buy": "43.90",
+    "sell": "44.90",
+    "updated_on": "2025-09-29",
+    "updated_on_time": "07:27 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/29/central-money-exchange-20250929T191624060) in the repository.