### PR TITLE
Central Money Exchange - September 29, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T215925144/README.md
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T215925144/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-29 21:59:25
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-29 |
+| Method | POST |
+| Timestamp | 2025-09-29T21:59:25.144077-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 30 Sep 2025 01:10:55 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=7EiEaDVXhkozRthwgf%2BYBMVSX%2BChK%2FMdV7bcHNRHEhdTuHs%2F4DCU%2FaxSeRC9zAhIKYRe55OLri9DlVA%2FL451mp0Z%2BZGProKX"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 986fd7e0ea8b1510-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.91.194.100  0.186ms  0.315ms  0.108ms 
+  2   140.204.28.36  10.155ms  9.923ms  9.813ms 
+  3   140.204.28.37  11.515ms  14.354ms  * 
+  4   141.101.72.87  15.366ms  18.163ms  12.201ms 
+  5   172.67.142.118  10.572ms  10.442ms  10.425ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 43.90 | 44.90 |

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T215925144/request.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T215925144/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-29T21:59:25.144077-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-29",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.91.194.100  0.186ms  0.315ms  0.108ms \n  2   140.204.28.36  10.155ms  9.923ms  9.813ms \n  3   140.204.28.37  11.515ms  14.354ms  * \n  4   141.101.72.87  15.366ms  18.163ms  12.201ms \n  5   172.67.142.118  10.572ms  10.442ms  10.425ms \n"
+}

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T215925144/response.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T215925144/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 30 Sep 2025 01:10:55 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=7EiEaDVXhkozRthwgf%2BYBMVSX%2BChK%2FMdV7bcHNRHEhdTuHs%2F4DCU%2FaxSeRC9zAhIKYRe55OLri9DlVA%2FL451mp0Z%2BZGProKX\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "986fd7e0ea8b1510-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.9000,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":44.9000,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"29-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"10:10 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/29/central-money-exchange-20250929T215925144/results.json
+++ b/exchange-rates/2025/09/29/central-money-exchange-20250929T215925144/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-09-29",
+    "updated_on_time": "10:10 PM"
+  },
+  "EUR": {
+    "buy": "43.90",
+    "sell": "44.90",
+    "updated_on": "2025-09-29",
+    "updated_on_time": "10:10 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/29/central-money-exchange-20250929T215925144) in the repository.