### PR TITLE
Central Money Exchange - September 30, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/30/central-money-exchange-20250930T101409847/README.md
+++ b/exchange-rates/2025/09/30/central-money-exchange-20250930T101409847/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-30 10:14:09
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-30 |
+| Method | POST |
+| Timestamp | 2025-09-30T10:14:09.847061-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 30 Sep 2025 13:25:09 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=jcKqYcBBBx2aIpskcJgqr0NqQ52yZIuaIrYfY9DNz%2B%2BG%2Bx%2FmQ%2F%2Bnyo1MqjscFjWDVNj0PHfgvE05vv2j7BQyMgwFl2jzJNgQPVo%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98740b6aae15a99e-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.226.203  0.272ms  0.219ms  0.152ms 
+  2   140.204.28.36  8.481ms  9.805ms  8.959ms 
+  3   140.204.28.37  12.727ms  *  12.688ms 
+  4   141.101.72.87  9.477ms  8.933ms  8.899ms 
+  5   172.67.142.118  10.594ms  10.450ms  10.498ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.10 |
+| EUR | 43.60 | 44.65 |

--- a/exchange-rates/2025/09/30/central-money-exchange-20250930T101409847/request.json
+++ b/exchange-rates/2025/09/30/central-money-exchange-20250930T101409847/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-30T10:14:09.847061-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-30",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.226.203  0.272ms  0.219ms  0.152ms \n  2   140.204.28.36  8.481ms  9.805ms  8.959ms \n  3   140.204.28.37  12.727ms  *  12.688ms \n  4   141.101.72.87  9.477ms  8.933ms  8.899ms \n  5   172.67.142.118  10.594ms  10.450ms  10.498ms \n"
+}

--- a/exchange-rates/2025/09/30/central-money-exchange-20250930T101409847/response.json
+++ b/exchange-rates/2025/09/30/central-money-exchange-20250930T101409847/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 30 Sep 2025 13:25:09 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=jcKqYcBBBx2aIpskcJgqr0NqQ52yZIuaIrYfY9DNz%2B%2BG%2Bx%2FmQ%2F%2Bnyo1MqjscFjWDVNj0PHfgvE05vv2j7BQyMgwFl2jzJNgQPVo%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98740b6aae15a99e-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.6000,\"SaleUsdExchangeRate\":38.1000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"30-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"10:25 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/30/central-money-exchange-20250930T101409847/results.json
+++ b/exchange-rates/2025/09/30/central-money-exchange-20250930T101409847/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.10",
+    "updated_on": "2025-09-30",
+    "updated_on_time": "10:25 AM"
+  },
+  "EUR": {
+    "buy": "43.60",
+    "sell": "44.65",
+    "updated_on": "2025-09-30",
+    "updated_on_time": "10:25 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/30/central-money-exchange-20250930T101409847) in the repository.