### PR TITLE
Central Money Exchange - September 30, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/09/30/central-money-exchange-20250930T113530360/README.md
+++ b/exchange-rates/2025/09/30/central-money-exchange-20250930T113530360/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-09-30 11:35:30
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-30 |
+| Method | POST |
+| Timestamp | 2025-09-30T11:35:30.360630-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 30 Sep 2025 14:46:31 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=KQKElnX9%2B4Vy5SKfXxsSEHNGI6jQ00IKZL31OHW7tL%2BZvdJlynaLwwMe2RqMqmLSbh0nzvkMvo%2BL2dFXupR3Wr8eOWEPwRatRPE%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 9874829c29ba1d4d-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.227.17  0.217ms  0.153ms  0.157ms 
+  2   140.204.28.36  10.035ms  10.104ms  29.754ms 
+  3   *  140.204.28.37  20.122ms  11.920ms 
+  4   141.101.72.31  13.155ms  12.414ms  12.276ms 
+  5   172.67.142.118  12.163ms  12.104ms  12.153ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.10 |
+| EUR | 43.60 | 44.65 |

--- a/exchange-rates/2025/09/30/central-money-exchange-20250930T113530360/request.json
+++ b/exchange-rates/2025/09/30/central-money-exchange-20250930T113530360/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-09-30T11:35:30.360630-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-09-30",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.227.17  0.217ms  0.153ms  0.157ms \n  2   140.204.28.36  10.035ms  10.104ms  29.754ms \n  3   *  140.204.28.37  20.122ms  11.920ms \n  4   141.101.72.31  13.155ms  12.414ms  12.276ms \n  5   172.67.142.118  12.163ms  12.104ms  12.153ms \n"
+}

--- a/exchange-rates/2025/09/30/central-money-exchange-20250930T113530360/response.json
+++ b/exchange-rates/2025/09/30/central-money-exchange-20250930T113530360/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 30 Sep 2025 14:46:31 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=KQKElnX9%2B4Vy5SKfXxsSEHNGI6jQ00IKZL31OHW7tL%2BZvdJlynaLwwMe2RqMqmLSbh0nzvkMvo%2BL2dFXupR3Wr8eOWEPwRatRPE%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "9874829c29ba1d4d-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.6000,\"SaleUsdExchangeRate\":38.1000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"30-Sep-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"11:46 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/09/30/central-money-exchange-20250930T113530360/results.json
+++ b/exchange-rates/2025/09/30/central-money-exchange-20250930T113530360/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.10",
+    "updated_on": "2025-09-30",
+    "updated_on_time": "11:46 AM"
+  },
+  "EUR": {
+    "buy": "43.60",
+    "sell": "44.65",
+    "updated_on": "2025-09-30",
+    "updated_on_time": "11:46 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/09/30/central-money-exchange-20250930T113530360) in the repository.