### PR TITLE
Central Money Exchange - October 1, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/10/01/central-money-exchange-20251001T120702273/README.md
+++ b/exchange-rates/2025/10/01/central-money-exchange-20251001T120702273/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-10-01 12:07:02
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-01 |
+| Method | POST |
+| Timestamp | 2025-10-01T12:07:02.273468-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 01 Oct 2025 15:18:50 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=rxtF%2FTxKx2kIV%2FNaRWKDBHQGDLpKKfi4n9CGQ3obm%2FefktdgLdq6TXtZc7odbFHcl%2FdamMXE2uMwPcX3wehEiJbzemxtyl4vU3A%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 987cef4f9a7f7c61-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.226.219  0.258ms  0.244ms  0.115ms 
+  2   140.204.28.36  10.015ms  10.185ms  9.997ms 
+  3   *  *  140.204.28.37  12.271ms 
+  4   141.101.72.83  12.168ms  11.003ms  10.942ms 
+  5   172.67.142.118  12.149ms  12.154ms  12.166ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.10 |
+| EUR | 43.50 | 44.55 |

--- a/exchange-rates/2025/10/01/central-money-exchange-20251001T120702273/request.json
+++ b/exchange-rates/2025/10/01/central-money-exchange-20251001T120702273/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-10-01T12:07:02.273468-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-01",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.226.219  0.258ms  0.244ms  0.115ms \n  2   140.204.28.36  10.015ms  10.185ms  9.997ms \n  3   *  *  140.204.28.37  12.271ms \n  4   141.101.72.83  12.168ms  11.003ms  10.942ms \n  5   172.67.142.118  12.149ms  12.154ms  12.166ms \n"
+}

--- a/exchange-rates/2025/10/01/central-money-exchange-20251001T120702273/response.json
+++ b/exchange-rates/2025/10/01/central-money-exchange-20251001T120702273/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 01 Oct 2025 15:18:50 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=rxtF%2FTxKx2kIV%2FNaRWKDBHQGDLpKKfi4n9CGQ3obm%2FefktdgLdq6TXtZc7odbFHcl%2FdamMXE2uMwPcX3wehEiJbzemxtyl4vU3A%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "987cef4f9a7f7c61-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.5000,\"SaleUsdExchangeRate\":38.1000,\"SaleEuroExchangeRate\":44.5500,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"01-Oct-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"12:18 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/10/01/central-money-exchange-20251001T120702273/results.json
+++ b/exchange-rates/2025/10/01/central-money-exchange-20251001T120702273/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.10",
+    "updated_on": "2025-10-01",
+    "updated_on_time": "12:18 PM"
+  },
+  "EUR": {
+    "buy": "43.50",
+    "sell": "44.55",
+    "updated_on": "2025-10-01",
+    "updated_on_time": "12:18 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/10/01/central-money-exchange-20251001T120702273) in the repository.