### PR TITLE
Central Money Exchange - October 2, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/10/02/central-money-exchange-20251002T095627725/README.md
+++ b/exchange-rates/2025/10/02/central-money-exchange-20251002T095627725/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-10-02 09:56:27
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-02 |
+| Method | POST |
+| Timestamp | 2025-10-02T09:56:27.725037-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Thu, 02 Oct 2025 13:07:56 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=A7r18I6ImP6roE70%2BWlz2DAPt%2BWIufDxmSzEKsUXDTKIBklZD3zpL0aPVJQrNzDHHv%2FtRA%2BBmG4J5urWQ6N1HNKYFQvu7hCi"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98846cea08105214-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.204.226.215  0.225ms  0.106ms  0.099ms 
+  2   140.204.28.36  8.443ms  8.405ms  8.357ms 
+  3   140.204.28.37  10.565ms  10.605ms  * 
+  4   141.101.72.27  38.745ms  29.200ms  22.789ms 
+  5   104.21.95.5  11.957ms  11.923ms  11.916ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.10 |
+| EUR | 43.50 | 44.55 |

--- a/exchange-rates/2025/10/02/central-money-exchange-20251002T095627725/request.json
+++ b/exchange-rates/2025/10/02/central-money-exchange-20251002T095627725/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-10-02T09:56:27.725037-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-02",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.204.226.215  0.225ms  0.106ms  0.099ms \n  2   140.204.28.36  8.443ms  8.405ms  8.357ms \n  3   140.204.28.37  10.565ms  10.605ms  * \n  4   141.101.72.27  38.745ms  29.200ms  22.789ms \n  5   104.21.95.5  11.957ms  11.923ms  11.916ms \n"
+}

--- a/exchange-rates/2025/10/02/central-money-exchange-20251002T095627725/response.json
+++ b/exchange-rates/2025/10/02/central-money-exchange-20251002T095627725/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Thu, 02 Oct 2025 13:07:56 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=A7r18I6ImP6roE70%2BWlz2DAPt%2BWIufDxmSzEKsUXDTKIBklZD3zpL0aPVJQrNzDHHv%2FtRA%2BBmG4J5urWQ6N1HNKYFQvu7hCi\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98846cea08105214-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.5000,\"SaleUsdExchangeRate\":38.1000,\"SaleEuroExchangeRate\":44.5500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"02-Oct-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"10:07 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/10/02/central-money-exchange-20251002T095627725/results.json
+++ b/exchange-rates/2025/10/02/central-money-exchange-20251002T095627725/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.10",
+    "updated_on": "2025-10-02",
+    "updated_on_time": "10:07 AM"
+  },
+  "EUR": {
+    "buy": "43.50",
+    "sell": "44.55",
+    "updated_on": "2025-10-02",
+    "updated_on_time": "10:07 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/10/02/central-money-exchange-20251002T095627725) in the repository.