### PR TITLE
Central Money Exchange - October 4, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/10/04/central-money-exchange-20251004T041053890/README.md
+++ b/exchange-rates/2025/10/04/central-money-exchange-20251004T041053890/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-10-04 04:10:53
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-04 |
+| Method | POST |
+| Timestamp | 2025-10-04T04:10:53.890014-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sat, 04 Oct 2025 07:22:58 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=%2FqVH3OtFdZezDqpESxpKWNIwJ4txtqEebK2d12%2FEPv45o5ITTkZgsNckSDsb7ZLhpEunTcyqPot4bagjzg3xO51Tdot9aCq%2BeZM%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 9892ee600b082f43-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.91.194.59  0.419ms  0.209ms  0.151ms 
+  2   140.204.28.32  8.566ms  8.369ms  8.493ms 
+  3   140.204.28.33  12.417ms  12.423ms  12.308ms 
+  4   141.101.72.27  9.372ms  8.983ms  17.078ms 
+  5   172.67.142.118  12.207ms  12.222ms  12.247ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.25 |
+| EUR | 43.65 | 44.65 |

--- a/exchange-rates/2025/10/04/central-money-exchange-20251004T041053890/request.json
+++ b/exchange-rates/2025/10/04/central-money-exchange-20251004T041053890/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-10-04T04:10:53.890014-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-04",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.91.194.59  0.419ms  0.209ms  0.151ms \n  2   140.204.28.32  8.566ms  8.369ms  8.493ms \n  3   140.204.28.33  12.417ms  12.423ms  12.308ms \n  4   141.101.72.27  9.372ms  8.983ms  17.078ms \n  5   172.67.142.118  12.207ms  12.222ms  12.247ms \n"
+}

--- a/exchange-rates/2025/10/04/central-money-exchange-20251004T041053890/response.json
+++ b/exchange-rates/2025/10/04/central-money-exchange-20251004T041053890/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sat, 04 Oct 2025 07:22:58 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=%2FqVH3OtFdZezDqpESxpKWNIwJ4txtqEebK2d12%2FEPv45o5ITTkZgsNckSDsb7ZLhpEunTcyqPot4bagjzg3xO51Tdot9aCq%2BeZM%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "9892ee600b082f43-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.6500,\"SaleUsdExchangeRate\":38.2500,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"04-Oct-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"04:22 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/10/04/central-money-exchange-20251004T041053890/results.json
+++ b/exchange-rates/2025/10/04/central-money-exchange-20251004T041053890/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.25",
+    "updated_on": "2025-10-04",
+    "updated_on_time": "04:22 AM"
+  },
+  "EUR": {
+    "buy": "43.65",
+    "sell": "44.65",
+    "updated_on": "2025-10-04",
+    "updated_on_time": "04:22 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/10/04/central-money-exchange-20251004T041053890) in the repository.