### PR TITLE
Central Money Exchange - October 5, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/10/05/central-money-exchange-20251005T084254777/README.md
+++ b/exchange-rates/2025/10/05/central-money-exchange-20251005T084254777/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-10-05 08:42:54
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-05 |
+| Method | POST |
+| Timestamp | 2025-10-05T08:42:54.777534-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sun, 05 Oct 2025 11:54:40 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=YBbITms17cVuf6K9gnGHRFB1z0j4Ak%2BruBcQ%2FP5FFex%2B%2B%2FBgRLz6Qflan1SkfgA25I0Z4Djxxp%2FG6rvS6er96r8RdmL3OXVRQ0U%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 989cb9bc9b110fed-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.91.194.101  0.194ms  0.213ms  0.123ms 
+  2   140.204.28.36  11.655ms  18.146ms  25.431ms 
+  3   140.204.28.37  39.021ms  41.677ms  19.574ms 
+  4   141.101.72.31  9.022ms  9.081ms  8.907ms 
+  5   104.21.95.5  9.028ms  8.893ms  8.945ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.40 |
+| EUR | 43.75 | 44.65 |

--- a/exchange-rates/2025/10/05/central-money-exchange-20251005T084254777/request.json
+++ b/exchange-rates/2025/10/05/central-money-exchange-20251005T084254777/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-10-05T08:42:54.777534-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-05",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.91.194.101  0.194ms  0.213ms  0.123ms \n  2   140.204.28.36  11.655ms  18.146ms  25.431ms \n  3   140.204.28.37  39.021ms  41.677ms  19.574ms \n  4   141.101.72.31  9.022ms  9.081ms  8.907ms \n  5   104.21.95.5  9.028ms  8.893ms  8.945ms \n"
+}

--- a/exchange-rates/2025/10/05/central-money-exchange-20251005T084254777/response.json
+++ b/exchange-rates/2025/10/05/central-money-exchange-20251005T084254777/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sun, 05 Oct 2025 11:54:40 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=YBbITms17cVuf6K9gnGHRFB1z0j4Ak%2BruBcQ%2FP5FFex%2B%2B%2FBgRLz6Qflan1SkfgA25I0Z4Djxxp%2FG6rvS6er96r8RdmL3OXVRQ0U%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "989cb9bc9b110fed-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.4000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"05-Oct-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"08:54 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/10/05/central-money-exchange-20251005T084254777/results.json
+++ b/exchange-rates/2025/10/05/central-money-exchange-20251005T084254777/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.40",
+    "updated_on": "2025-10-05",
+    "updated_on_time": "08:54 AM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.65",
+    "updated_on": "2025-10-05",
+    "updated_on_time": "08:54 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/10/05/central-money-exchange-20251005T084254777) in the repository.