### PR TITLE
Central Money Exchange - October 5, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/10/05/central-money-exchange-20251005T112615811/README.md
+++ b/exchange-rates/2025/10/05/central-money-exchange-20251005T112615811/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-10-05 11:26:15
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-05 |
+| Method | POST |
+| Timestamp | 2025-10-05T11:26:15.811953-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Sun, 05 Oct 2025 14:37:13 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=J4sG6KKwfKHtsxttuwayDx0u1fiOOcx1KjQwcdFus%2By89nXrR99qS4r70EEohWbs52qU1p6PQyhdKnapXlfSyh3l02%2F48qWZ2Ak%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 989da7d83a122ef8-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.204.226.203  0.302ms  0.130ms  0.121ms 
+  2   140.204.28.32  9.940ms  10.021ms  9.952ms 
+  3   140.204.28.33  12.226ms  *  12.651ms 
+  4   141.101.72.87  12.886ms  12.959ms  13.324ms 
+  5   104.21.95.5  10.649ms  10.551ms  10.616ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.40 |
+| EUR | 43.75 | 44.65 |

--- a/exchange-rates/2025/10/05/central-money-exchange-20251005T112615811/request.json
+++ b/exchange-rates/2025/10/05/central-money-exchange-20251005T112615811/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-10-05T11:26:15.811953-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-05",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.204.226.203  0.302ms  0.130ms  0.121ms \n  2   140.204.28.32  9.940ms  10.021ms  9.952ms \n  3   140.204.28.33  12.226ms  *  12.651ms \n  4   141.101.72.87  12.886ms  12.959ms  13.324ms \n  5   104.21.95.5  10.649ms  10.551ms  10.616ms \n"
+}

--- a/exchange-rates/2025/10/05/central-money-exchange-20251005T112615811/response.json
+++ b/exchange-rates/2025/10/05/central-money-exchange-20251005T112615811/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Sun, 05 Oct 2025 14:37:13 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=J4sG6KKwfKHtsxttuwayDx0u1fiOOcx1KjQwcdFus%2By89nXrR99qS4r70EEohWbs52qU1p6PQyhdKnapXlfSyh3l02%2F48qWZ2Ak%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "989da7d83a122ef8-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.4000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1250,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1250,\"Day\":null,\"BusinessDate\":\"05-Oct-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"11:37 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/10/05/central-money-exchange-20251005T112615811/results.json
+++ b/exchange-rates/2025/10/05/central-money-exchange-20251005T112615811/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.40",
+    "updated_on": "2025-10-05",
+    "updated_on_time": "11:37 AM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.65",
+    "updated_on": "2025-10-05",
+    "updated_on_time": "11:37 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/10/05/central-money-exchange-20251005T112615811) in the repository.