### PR TITLE
Central Money Exchange - October 6, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/10/06/central-money-exchange-20251006T225409384/README.md
+++ b/exchange-rates/2025/10/06/central-money-exchange-20251006T225409384/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-10-06 22:54:09
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-06 |
+| Method | POST |
+| Timestamp | 2025-10-06T22:54:09.384560-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 07 Oct 2025 02:05:41 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=Ay118HtqsioEmD99%2Bl3aQZB7vMNdCu0OxBRrvd8Xe1bwFCkR%2BdUr4Dvo37PS0thh6JrNrs9Qhji8b2WDWotwmLTeYs%2BDlMLq3LE%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98a9d5b8bed6f7c5-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (104.21.95.5), 15 hops max
+  1   140.91.195.207  0.170ms  0.118ms  0.108ms 
+  2   140.204.28.36  11.607ms  11.483ms  11.494ms 
+  3   140.204.28.37  14.184ms  11.250ms  * 
+  4   141.101.72.83  10.660ms  11.349ms  10.663ms 
+  5   104.21.95.5  8.992ms  8.908ms  8.947ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.40 |
+| EUR | 43.75 | 44.65 |

--- a/exchange-rates/2025/10/06/central-money-exchange-20251006T225409384/request.json
+++ b/exchange-rates/2025/10/06/central-money-exchange-20251006T225409384/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-10-06T22:54:09.384560-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-06",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (104.21.95.5), 15 hops max\n  1   140.91.195.207  0.170ms  0.118ms  0.108ms \n  2   140.204.28.36  11.607ms  11.483ms  11.494ms \n  3   140.204.28.37  14.184ms  11.250ms  * \n  4   141.101.72.83  10.660ms  11.349ms  10.663ms \n  5   104.21.95.5  8.992ms  8.908ms  8.947ms \n"
+}

--- a/exchange-rates/2025/10/06/central-money-exchange-20251006T225409384/response.json
+++ b/exchange-rates/2025/10/06/central-money-exchange-20251006T225409384/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 07 Oct 2025 02:05:41 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=Ay118HtqsioEmD99%2Bl3aQZB7vMNdCu0OxBRrvd8Xe1bwFCkR%2BdUr4Dvo37PS0thh6JrNrs9Qhji8b2WDWotwmLTeYs%2BDlMLq3LE%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98a9d5b8bed6f7c5-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.4000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"06-Oct-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"11:05 PM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/10/06/central-money-exchange-20251006T225409384/results.json
+++ b/exchange-rates/2025/10/06/central-money-exchange-20251006T225409384/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.40",
+    "updated_on": "2025-10-06",
+    "updated_on_time": "11:05 PM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.65",
+    "updated_on": "2025-10-06",
+    "updated_on_time": "11:05 PM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/10/06/central-money-exchange-20251006T225409384) in the repository.