### PR TITLE
Central Money Exchange - October 7, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/10/07/central-money-exchange-20251007T014343641/README.md
+++ b/exchange-rates/2025/10/07/central-money-exchange-20251007T014343641/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-10-07 01:43:43
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-07 |
+| Method | POST |
+| Timestamp | 2025-10-07T01:43:43.641590-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Tue, 07 Oct 2025 04:54:54 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=EWQjdFArUBv19c51ClIF0hJ1vwyPlRqxujjKzrnjj7%2FzC2zOyfZBlw0Eqh4MgyGqFu9mqNil%2BGl3uGFtatIpnPP77dMZW9hrtIU%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98aacd989e807bd4-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.226.241  0.304ms  0.143ms  0.140ms 
+  2   140.204.28.36  9.618ms  8.523ms  8.342ms 
+  3   140.204.28.37  25.322ms  27.675ms  20.045ms 
+  4   141.101.72.83  24.840ms  9.004ms  11.955ms 
+  5   172.67.142.118  10.725ms  10.541ms  10.612ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.70 | 38.40 |
+| EUR | 43.75 | 44.65 |

--- a/exchange-rates/2025/10/07/central-money-exchange-20251007T014343641/request.json
+++ b/exchange-rates/2025/10/07/central-money-exchange-20251007T014343641/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-10-07T01:43:43.641590-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-07",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.226.241  0.304ms  0.143ms  0.140ms \n  2   140.204.28.36  9.618ms  8.523ms  8.342ms \n  3   140.204.28.37  25.322ms  27.675ms  20.045ms \n  4   141.101.72.83  24.840ms  9.004ms  11.955ms \n  5   172.67.142.118  10.725ms  10.541ms  10.612ms \n"
+}

--- a/exchange-rates/2025/10/07/central-money-exchange-20251007T014343641/response.json
+++ b/exchange-rates/2025/10/07/central-money-exchange-20251007T014343641/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Tue, 07 Oct 2025 04:54:54 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=EWQjdFArUBv19c51ClIF0hJ1vwyPlRqxujjKzrnjj7%2FzC2zOyfZBlw0Eqh4MgyGqFu9mqNil%2BGl3uGFtatIpnPP77dMZW9hrtIU%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98aacd989e807bd4-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.7000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.4000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"07-Oct-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"01:54 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/10/07/central-money-exchange-20251007T014343641/results.json
+++ b/exchange-rates/2025/10/07/central-money-exchange-20251007T014343641/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.70",
+    "sell": "38.40",
+    "updated_on": "2025-10-07",
+    "updated_on_time": "01:54 AM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.65",
+    "updated_on": "2025-10-07",
+    "updated_on_time": "01:54 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/10/07/central-money-exchange-20251007T014343641) in the repository.