### PR TITLE
Central Money Exchange - October 8, 2025 Rates Snapshot

### DIFF
--- a/exchange-rates/2025/10/08/central-money-exchange-20251008T070331182/README.md
+++ b/exchange-rates/2025/10/08/central-money-exchange-20251008T070331182/README.md
@@ -1,0 +1,64 @@
+# Central Money Exchange Rates Snapshot 2025-10-08 07:03:31
+## Request Details
+
+| Property | Value |
+|----------|-------|
+| URL | https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-08 |
+| Method | POST |
+| Timestamp | 2025-10-08T07:03:31.182400-03:00 |
+| Local IP | 127.0.1.1 |
+    
+## Request headers table
+
+| Header | Value |
+|--------|-------|
+| User-Agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 |
+| Accept | */* |
+| Accept-Language | es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6 |
+| Accept-Encoding | gzip, deflate |
+| Origin | https://www.cme.sr |
+| Referer | https://www.cme.sr/ |
+| X-Requested-With | XMLHttpRequest |
+| Cache-Control | no-cache |
+| Pragma | no-cache |
+| Content-Length | 0 |
+
+    
+## Response headers table
+| Header | Value |
+|--------|-------|
+| Date | Wed, 08 Oct 2025 10:14:37 GMT |
+| Content-Type | application/json; charset=utf-8 |
+| Transfer-Encoding | chunked |
+| Connection | keep-alive |
+| Cache-Control | private |
+| Server | cloudflare |
+| x-aspnetmvc-version | 5.2 |
+| x-aspnet-version | 4.0.30319 |
+| x-powered-by | ASP.NET |
+| cf-cache-status | DYNAMIC |
+| Nel | {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800} |
+| Report-To | {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=XnBy2cnRBPVdzM8XXoKM%2B8WK3Jh0eOBgOlHldPT9ZNznlzjbyuRI6ENXZ%2F3EBcVBORzVblB7jCN0Ee1RK5prVpquLIdmFCY0QSk%3D"}]} |
+| Content-Encoding | gzip |
+| CF-RAY | 98b4df50cfee7d74-LAX |
+| alt-svc | h3=":443"; ma=86400 |
+
+## Traceroute 
+
+```
+traceroute to www.cme.sr (172.67.142.118), 15 hops max
+  1   140.204.226.233  0.209ms  0.062ms  0.260ms 
+  2   140.204.28.36  11.542ms  11.400ms  11.630ms 
+  3   140.204.28.37  11.044ms  10.815ms  * 
+  4   141.101.72.31  27.615ms  23.902ms  12.951ms 
+  5   172.67.142.118  8.875ms  8.840ms  8.838ms 
+
+```
+
+
+## Table of rates
+
+| Currency | Buy Rate | Sell Rate |
+|----------|----------|-----------|
+| USD | 37.80 | 38.50 |
+| EUR | 43.75 | 44.65 |

--- a/exchange-rates/2025/10/08/central-money-exchange-20251008T070331182/request.json
+++ b/exchange-rates/2025/10/08/central-money-exchange-20251008T070331182/request.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2025-10-08T07:03:31.182400-03:00",
+  "url": "https://www.cme.sr/Home/GetTodaysExchangeRates/?BusinessDate=2025-10-08",
+  "method": "POST",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "es-US,es-419;q=0.9,es;q=0.8,en;q=0.7,nl;q=0.6",
+    "Accept-Encoding": "gzip, deflate",
+    "Origin": "https://www.cme.sr",
+    "Referer": "https://www.cme.sr/",
+    "X-Requested-With": "XMLHttpRequest",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Content-Length": "0"
+  },
+  "body": "None",
+  "ip_local": "127.0.1.1",
+  "traceroute": "traceroute to www.cme.sr (172.67.142.118), 15 hops max\n  1   140.204.226.233  0.209ms  0.062ms  0.260ms \n  2   140.204.28.36  11.542ms  11.400ms  11.630ms \n  3   140.204.28.37  11.044ms  10.815ms  * \n  4   141.101.72.31  27.615ms  23.902ms  12.951ms \n  5   172.67.142.118  8.875ms  8.840ms  8.838ms \n"
+}

--- a/exchange-rates/2025/10/08/central-money-exchange-20251008T070331182/response.json
+++ b/exchange-rates/2025/10/08/central-money-exchange-20251008T070331182/response.json
@@ -1,0 +1,21 @@
+{
+  "status_code": 200,
+  "headers": {
+    "Date": "Wed, 08 Oct 2025 10:14:37 GMT",
+    "Content-Type": "application/json; charset=utf-8",
+    "Transfer-Encoding": "chunked",
+    "Connection": "keep-alive",
+    "Cache-Control": "private",
+    "Server": "cloudflare",
+    "x-aspnetmvc-version": "5.2",
+    "x-aspnet-version": "4.0.30319",
+    "x-powered-by": "ASP.NET",
+    "cf-cache-status": "DYNAMIC",
+    "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+    "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=XnBy2cnRBPVdzM8XXoKM%2B8WK3Jh0eOBgOlHldPT9ZNznlzjbyuRI6ENXZ%2F3EBcVBORzVblB7jCN0Ee1RK5prVpquLIdmFCY0QSk%3D\"}]}",
+    "Content-Encoding": "gzip",
+    "CF-RAY": "98b4df50cfee7d74-LAX",
+    "alt-svc": "h3=\":443\"; ma=86400"
+  },
+  "text": "[{\"BuyUsdExchangeRate\":37.8000,\"BuyEuroExchangeRate\":43.7500,\"SaleUsdExchangeRate\":38.5000,\"SaleEuroExchangeRate\":44.6500,\"ExchangeUsdRate\":1.1200,\"ExchangeEuroRate\":1.1450,\"ExchangeUsdRateNew\":1.1450,\"ExchangeEuroRateNew\":1.1200,\"Day\":null,\"BusinessDate\":\"08-Oct-2025\",\"USDBalance\":1,\"EUROBalance\":1,\"UpdatedTime\":\"07:14 AM\",\"NonCashBuyUsdExchangeRate\":0.0001,\"NonCashBuyEuroExchangeRate\":0.0001,\"NonCashSaleUsdExchangeRate\":0.0002,\"NonCashSaleEuroExchangeRate\":0.0002,\"NonCashExchangeUsdRate\":0.0002,\"NonCashExchangeEuroRate\":0.0001,\"IsShow\":false,\"AnnounceHtml\":\"\"}]"
+}

--- a/exchange-rates/2025/10/08/central-money-exchange-20251008T070331182/results.json
+++ b/exchange-rates/2025/10/08/central-money-exchange-20251008T070331182/results.json
@@ -1,0 +1,14 @@
+{
+  "USD": {
+    "buy": "37.80",
+    "sell": "38.50",
+    "updated_on": "2025-10-08",
+    "updated_on_time": "07:14 AM"
+  },
+  "EUR": {
+    "buy": "43.75",
+    "sell": "44.65",
+    "updated_on": "2025-10-08",
+    "updated_on_time": "07:14 AM"
+  }
+}


### PR DESCRIPTION
To see the full snapshot, please visit this  [folder](/divengine/paramaribo-info-2025/tree/main/exchange-rates/2025/10/08/central-money-exchange-20251008T070331182) in the repository.